### PR TITLE
Fixes link in ExampleExtension context file and documentation

### DIFF
--- a/extensions/exampleExtension/context.json
+++ b/extensions/exampleExtension/context.json
@@ -1,11 +1,11 @@
 {
   "@context": {
-    "obi": "https://w3id.org/openbadges#",
+    "extensions": "https://w3id.org/openbadges/extensions#",
     "exampleProperty": "http://schema.org/text"
   },
   "obi:validation": [
     {
-      "obi:validatesType": "obi:extensions/#ExampleExtension",
+      "obi:validatesType": "extensions:ExampleExtension",
       "obi:validationSchema": "https://openbadgespec.org/extensions/exampleExtension/schema.json"
     }
   ]

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -30,7 +30,7 @@ This is a definition of an example extension. If it were a real extension, it wo
 Property     | Type        | Value Description
 -------------|-------------|---------
 **@context** | context IRI | [https://openbadgespec.org/extensions/exampleExtension/context.json](./exampleExtension/context.json)
-**type**    | type IRI array |`['Extension', 'extensions:ExampleExtension']`
+**type**    | type IRI array |`['Extension', 'Extensions:ExampleExtension']`
 **exampleProperty** | string | Any text the implementer likes.
 
 </div>


### PR DESCRIPTION
This is an example of the work that must be done across all extensions as part of the Extensions Cleanup Posse that @jbohrer was going to marshall. There were two small errors in the ExampleExtension fixed in this small PR.
* The IRI for the validatesType in the context was incorrect. 
* The documentation had an additional mismatch with the context on what type it instructed developers to use.

Each of these errors made it impossible to make an implementation of this extension that would pass validation. The JSON-schema for an extension will be applied to the value of the data that is compacted into a context of `{"@context": [OB_V2_CONTEXT, EXTENSION_CONTEXT]}`