### PR TITLE
Geolocation extension fix

### DIFF
--- a/extensions/exampleExtension/context.json
+++ b/extensions/exampleExtension/context.json
@@ -1,11 +1,11 @@
 {
   "@context": {
-    "obi": "https://w3id.org/openbadges#",
+    "extensions": "https://w3id.org/openbadges/extensions#",
     "exampleProperty": "http://schema.org/text"
   },
   "obi:validation": [
     {
-      "obi:validatesType": "obi:extensions/#ExampleExtension",
+      "obi:validatesType": "extensions:ExampleExtension",
       "obi:validationSchema": "https://openbadgespec.org/extensions/exampleExtension/schema.json"
     }
   ]

--- a/extensions/geoCoordinatesExtension/context.json
+++ b/extensions/geoCoordinatesExtension/context.json
@@ -7,7 +7,7 @@
     "name": "schema:name",
     "description": "schema:description",
     "latitude": "schema:latitude",
-    "longitude": "schema:longitude"    
+    "longitude": "schema:longitude"
   },
   "obi:validation": [
     {

--- a/extensions/geoCoordinatesExtension/schema.json
+++ b/extensions/geoCoordinatesExtension/schema.json
@@ -13,7 +13,7 @@
         "longitude": { "type": "number" }
       },
       "required": ["latitude", "longitude"]
-    },
-    "required": ["description", "geo"] 
-  }
+    }
+  },
+  "required": ["description", "geo"] 
 }

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -30,7 +30,7 @@ This is a definition of an example extension. If it were a real extension, it wo
 Property     | Type        | Value Description
 -------------|-------------|---------
 **@context** | context IRI | [https://openbadgespec.org/extensions/exampleExtension/context.json](./exampleExtension/context.json)
-**type**    | type IRI array |`['Extension', 'Extensions:ExampleExtension']`
+**type**    | type IRI array |`['Extension', 'extensions:ExampleExtension']`
 **exampleProperty** | string | Any text the implementer likes.
 
 </div>

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -30,7 +30,7 @@ This is a definition of an example extension. If it were a real extension, it wo
 Property     | Type        | Value Description
 -------------|-------------|---------
 **@context** | context IRI | [https://openbadgespec.org/extensions/exampleExtension/context.json](./exampleExtension/context.json)
-**type**    | type IRI array |`['Extension', 'extensions:ExampleExtension']`
+**type**    | type IRI array |`['Extension', 'Extensions:ExampleExtension']`
 **exampleProperty** | string | Any text the implementer likes.
 
 </div>

--- a/extensions/index.md
+++ b/extensions/index.md
@@ -93,7 +93,7 @@ Property     | Type        | Value Description
 ### <a id="GeoCoordinates"></a>Geo Location
 _Authors: [Doug Belshaw](http://dougbelshaw.com) and [Kerri Lemoie](https://github.com/kayaelle)_
 
-An extension allowing for the addition of the geographic coordinates associated with a badge object. For example, geolocation could represent where a Badge Class is available, where a badge was earned or the location of an issuer. The required description property allows implementers to be more specific about the reason location is included. The extended value takes
+An extension allowing for the addition of the geographic coordinates associated with a badge object. For example, geolocation could represent where a BadgeClass is available, where a badge Assertion was earned or the location of an issuer. The required description property allows implementers to be more specific about the reason location is included.
 
 <div class="table-wrapper">
 
@@ -101,11 +101,11 @@ Property     | Type        | Value Description
 -------------|-------------|---------
 **@context** | context IRI | [https://w3id.org/openbadges/extensions/geoCoordinatesExtension/context.json](https://w3id.org/openbadges/extensions/geoCoordinatesExtension/context.json)
 **type**    | type IRI array |`['Extension', 'schema:Place' 'extensions:GeoCoordinates']`
-**name** | text | The place's name, if available
+name | text | The place's name, if available
 **description** | text | A description of the location
-**geo** | object | The GeoCoordinates of a location (containing the following properties)
+**geo** | <a href="#GeoCoordinates">GeoCordinates</a> | The GeoCoordinates of a location (containing the following properties)
 
-**GeoCoordinates**:
+<a name="GeoCordinates"></a>**GeoCoordinates**:
 
 Property     | Type        | Value Description
 -------------|-------------|---------


### PR DESCRIPTION
The Extensions Cleanup Posse is in full (unofficial) swing. (Merge PR #173 first for a clean diff here, as this includes that commit)

Fixes an error with the GeoLocationExtension JSON-schema, where the "required" declaration was in an invalid location in the file, so it wasn't a valid schema. Now it will be possible to publish a valid instance of the extension.