### PR TITLE
extensions/index.md Removed typo to fix heading size issue

### DIFF
--- a/extensions/index.md
+++ b/extensions/index.md
@@ -52,6 +52,7 @@ Assertion, BadgeClass, Issuer
 2. [Assessment](https://www.imsglobal.org/spec/ob-assessment/v1p0/) - This extension allows issuers to embed metadata about assessment(s) performed in the badge awarding process, potentially including some questions and related rubric data. 
 
 3. [Extra Description](http://imsglobal.github.io/openbadges-specification/extensions/extraDescription/) - Allows issuers to add additional descriptive fields to a BadgeClass or Issuer Profile.
+
 ---
 
 ## <a id="CommunityExtensions"></a> Community Extensions


### PR DESCRIPTION
Added empty line between horizontal rule and Community Extensions heading. Prior line of text was rendered incorrectly as h2.