### PR TITLE
Modify request payloads and response envelopes to separate signed and unsigned assertions

### DIFF
--- a/ob_v2p1/ob-spec-v2p1.html
+++ b/ob_v2p1/ob-spec-v2p1.html
@@ -808,8 +808,9 @@ grant_type=authorization_code
       <h3>Response Envelope</h3>
       <p>
         Responses from all APIs in this document are wrapped in a JSON envelope. All response envelopes have a 
-        <code>status</code> propperty and a <code>results</code> property. The type of each result in the
-        <code>results</code> array is defined in the <a href="#api-endpoints">Endpoints</a> section.
+        <code>status</code> property and one or more result properties. The property name(s) and expected
+        data types for values of each result property is defined in the <a href="#api-responses">Responses</a> 
+        section for each endpoint.
       </p>
       <section id="api-envelope-pagination">
         <h4>Pagination</h4>
@@ -1353,7 +1354,7 @@ Link:
               <td>The <a href="#api-envelope-status">Status</a> object describing the success or failure of the request.</td>
             </tr>
             <tr>
-              <td><code>results</code></td>
+              <td><code>profile</code></td>
               <td>No</td>
               <td>
                 The matching Profile in an array with exactly one element. Not required if the request was not
@@ -1370,7 +1371,7 @@ Link:
         "statusText": "OK"
     },
 
-    "results": [
+    "profile": [
         {
             "@context": "https://w3id.org/openbadges/v2",
             "id": "https://host.example.com/profile/12345",
@@ -1400,7 +1401,7 @@ Link:
               <td>The <a href="#api-envelope-status">Status</a> object describing the success or failure of the request.</td>
             </tr>
             <tr>
-              <td><code>results</code></td>
+              <td><code>profile</code></td>
               <td>No</td>
               <td>
                 The updated Profile in an array with exactly one element. Not required if the request was not
@@ -1417,7 +1418,7 @@ Link:
         "statusText": "OK"
     },
 
-    "results": [
+    "profile": [
         {
             "@context": "https://w3id.org/openbadges/v2",
             "id": "https://host.example.com/profile/12345",

--- a/ob_v2p1/ob-spec-v2p1.html
+++ b/ob_v2p1/ob-spec-v2p1.html
@@ -1273,11 +1273,11 @@ Link:
               </td>
             </tr>
             <tr>
-              <td><code>signedBadges</code></td>
+              <td><code>signedAssertions</code></td>
               <td>No</td>
               <td>
                 The matching <a href="#epi-signedbadge">SignedBadge</a> objects. The total number of assertions and signed
-                badges should not exceed the
+                assertions should not exceed the
                 [pageination limit](#api-envelope-pagination). Not required if the request was not processed successfully.
               </td>
             </tr>
@@ -1298,7 +1298,7 @@ Link:
           ...
         }
     ],
-    "signedBadges": [
+    "signedAssertions": [
         {
           "@context": "https://purl.imsglobal.org/spec/ob/v2p1/ob_v2p1.jsonld"
           "id": "urn:uuid:3d339b63-cab3-4951-a574-8faf45d1b802",

--- a/ob_v2p1/ob-spec-v2p1.html
+++ b/ob_v2p1/ob-spec-v2p1.html
@@ -807,27 +807,10 @@ grant_type=authorization_code
     <section id="api-envelope">
       <h3>Response Envelope</h3>
       <p>
-        Responses from all APIs in this document are wrapped in a JSON envelope. The type of each result in the
-        <code>results</code> array is specified by the result <code>type</code>. Allowable types are defined
-        in the <a href="#api-endpoints">Endpoints</a> section.
+        Responses from all APIs in this document are wrapped in a JSON envelope. All response envelopes have a 
+        <code>status</code> propperty and a <code>results</code> property. The type of each result in the
+        <code>results</code> array is defined in the <a href="#api-endpoints">Endpoints</a> section.
       </p>
-      <pre>
-{
-    "status": {
-        "error": null,
-        "statusCode": 200,
-        "statusText": "OK"
-    },
-
-    "results": [
-        {
-          "@context":"https://w3id.org/openbadges/v2",
-          "id":"https://issuer.example.com/api/v20/assertion/1234567",
-          "type":"Assertion"
-        }
-    ]
-}
-          </pre>
       <section id="api-envelope-pagination">
         <h4>Pagination</h4>
         <p>Pagination is controlled by two query string parameters appended to the request.</p>
@@ -1266,6 +1249,39 @@ Link:
       <h3>Responses</h3>
       <section id="api-responses-get-assertions-200">
         <h4>200 GET Assertions Response</h4>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Required</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>status</code></td>
+              <td>Yes</td>
+              <td>The <a href="#api-envelope-status">Status</a> object describing the success or failure of the request.</td>
+            </tr>
+            <tr>
+              <td><code>assertions</code></td>
+              <td>No</td>
+              <td>
+                The matching Assertions. The total number of assertions and signed baddges should not exceed the
+                [pageination limit](#api-envelope-pagination). Not required if the request was not processed successfully.
+              </td>
+            </tr>
+            <tr>
+              <td><code>signedBadges</code></td>
+              <td>No</td>
+              <td>
+                The matching <a href="#epi-signedbadge">SignedBadge</a> objects. The total number of assertions and signed
+                badges should not exceed the
+                [pageination limit](#api-envelope-pagination). Not required if the request was not processed successfully.
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <pre>
 {
     "status": {
@@ -1273,13 +1289,15 @@ Link:
         "statusCode": 200,
         "statusText": "OK"
     },
-
-    "results": [
+    "assertions": [
         {
           "@context": "https://w3id.org/openbadges/v2",
           "id": "https://issuer.example.com/api/v20/assertion/1234567",
-          "type": "Assertion"
-        },
+          "type": "Assertion",
+          ...
+        }
+    ],
+    "signedBadges": [
         {
           "@context": "https://purl.imsglobal.org/spec/ob/v2p1/ob_v2p1.jsonld"
           "id": "urn:uuid:3d339b63-cab3-4951-a574-8faf45d1b802",
@@ -1292,6 +1310,22 @@ Link:
       </section>
       <section id="api-responses-post-assertions-200">
         <h4>200 POST Assertion Response</h4>
+        <table>
+            <thead>
+              <tr>
+                <th>Property</th>
+                <th>Required</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>status</code></td>
+                <td>Yes</td>
+                <td>The <a href="#api-envelope-status">Status</a> object describing the success or failure of the request.</td>
+              </tr>
+            </tbody>
+        </table>
         <pre>
 {
     "status": {
@@ -1304,6 +1338,30 @@ Link:
       </section>
       <section id="api-responses-get-profile-200">
         <h4>200 GET Profile Response</h4>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Required</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>status</code></td>
+              <td>Yes</td>
+              <td>The <a href="#api-envelope-status">Status</a> object describing the success or failure of the request.</td>
+            </tr>
+            <tr>
+              <td><code>results</code></td>
+              <td>No</td>
+              <td>
+                The matching Profile in an array with exactly one element. Not required if the request was not
+                processed successfully.
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <pre>
 {
     "status": {
@@ -1327,6 +1385,30 @@ Link:
       </section>
       <section id="api-responses-post-profile-200">
         <h4>200 POST Profile Response</h4>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Required</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>status</code></td>
+              <td>Yes</td>
+              <td>The <a href="#api-envelope-status">Status</a> object describing the success or failure of the request.</td>
+            </tr>
+            <tr>
+              <td><code>results</code></td>
+              <td>No</td>
+              <td>
+                The updated Profile in an array with exactly one element. Not required if the request was not
+                processed successfully.
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <pre>
 {
     "status": {

--- a/ob_v2p1/ob-spec-v2p1.html
+++ b/ob_v2p1/ob-spec-v2p1.html
@@ -808,9 +808,8 @@ grant_type=authorization_code
       <h3>Response Envelope</h3>
       <p>
         Responses from all APIs in this document are wrapped in a JSON envelope. All response envelopes have a 
-        <code>status</code> property and one or more result properties. The property name(s) and expected
-        data types for values of each result property is defined in the <a href="#api-responses">Responses</a> 
-        section for each endpoint.
+        <code>status</code> property and one or more result properties. The result property name(s) and data types 
+        are defined in the <a href="#api-responses">Responses</a> section for each endpoint.
       </p>
       <section id="api-envelope-pagination">
         <h4>Pagination</h4>
@@ -1268,8 +1267,8 @@ Link:
               <td><code>assertions</code></td>
               <td>No</td>
               <td>
-                The matching Assertions. The total number of assertions and signed baddges should not exceed the
-                [pageination limit](#api-envelope-pagination). Not required if there are no unsigned assertions.
+                The matching Assertions. The total number of assertions and signed assertions should not exceed the
+                <a href="#api-envelope-pagination">pagination limit</a>. Not required if there are no unsigned assertions.
               </td>
             </tr>
             <tr>
@@ -1278,7 +1277,7 @@ Link:
               <td>
                 The matching <a href="#epi-signedbadge">SignedBadge</a> objects. The total number of assertions and signed
                 assertions should not exceed the
-                [pageination limit](#api-envelope-pagination). Not required if there are no signed assertions.
+                <a href="#api-envelope-pagination">pagination limit</a>. Not required if there are no signed assertions.
               </td>
             </tr>
           </tbody>

--- a/ob_v2p1/ob-spec-v2p1.html
+++ b/ob_v2p1/ob-spec-v2p1.html
@@ -888,19 +888,30 @@ Link:
           </pre>
       </section>
     </section>
-    <section id="api-signedbadge">
-      <h3>SignedBadge Object</h3>
+    <section id="api-assertionpayload">
+      <h3>Assertion Payload</h3>
       <p>
-        SignedBadge is a JSON-LD document that contains a signed badge as defined in Open Badges 2.0 [[OB-20]].
-        An example may look like this:
+        An Assertion Payload contains either a signed or unsigned Assertion. If both are specified,
+        the unsigned Assertion MUST be ignored. Null values MAY be omitted.
       </p>
-      <pre>
-        {
-          "id": "urn:uuid:3d339b63-cab3-4951-a574-8faf45d1b802",
-          "type": "SignedBadge",
-          "compactJws": "eyJhbGciOiJSUzI1NiJ9.ew0KICAiQGNvbnRleHQiOiAiaHR0cHM6Ly93M2lkLm9yZy9vcGVuYmFkZ2VzL3YyIiwNCiAgInR5cGUiOiAiQXNzZXJ0aW9uIiwNCiAgImlkIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3RpY3MtYmFkZ2UuanNvbiIsDQogICJyZWNpcGllbnQiOiB7DQogICAgInR5cGUiOiAiZW1haWwiLA0KICAgICJoYXNoZWQiOiB0cnVlLA0KICAgICJzYWx0IjogImRlYWRzZWEiLA0KICAgICJpZGVudGl0eSI6ICJzaGEyNTYkYzdlZjg2NDA1YmE3MWI4NWFjZDhlMmU5NTE2NmM0YjExMTQ0ODA4OWYyZTE1OTlmNDJmZTFiYmE0NmU4NjVjNSINCiAgfSwNCiAgImltYWdlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3QtYmFkZ2UucG5nIiwNCiAgImV2aWRlbmNlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3Qtd29yay5odG1sIiwNCiAgImlzc3VlZE9uIjogIjIwMTYtMTItMzFUMjM6NTk6NTlaIiwNCiAgImJhZGdlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvcm9ib3RpY3MtYmFkZ2UuanNvbiIsDQogICJ2ZXJpZnkiOiB7DQogICAgInR5cGUiOiAiU2lnbmVkQmFkZ2UiLA0KICAgICJjcmVhdG9yIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvcHVibGljS2V5Ig0KICB9DQp9.Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg"
-        }
-      </pre>
+      <p>
+        Three examples:
+      </p>
+<pre>
+  {
+    "assertion": { ... },
+    "signedAssertion": null
+  }
+
+  {
+    "assertion": null,
+    "signedAssertion": "abced..."
+  }
+
+  {
+    "assertion": { ... }
+  }
+</pre>
       <table>
         <thead>
           <tr>
@@ -912,22 +923,16 @@ Link:
         </thead>
         <tbody>
           <tr>
-            <td><code>id</code></td>
-            <td>IRI</td>
+            <td><code>assertion</code></td>
+            <td>Assertion</td>
             <td>No</td>
-            <td>Unique IRI for the Assertion. If present, this MUST match the <code>id</code> of the signed badge.</td>
+            <td>An unsigned Assertion object in serialized JSON-LD.</td>
           </tr>
           <tr>
-            <td><code>type</code></td>
-            <td>JSON-LD type</td>
+            <td><code>signedAssertion</code></td>
+            <td>String</td>
             <td>No</td>
-            <td>If present, must be the string "SignedBadge".</td>
-          </tr>
-          <tr>
-            <td><code>compactJws</code></td>
-            <td>JWS</td>
-            <td>Yes</td>
-            <td>The signed badge as defined in Open Badges 2.0 [[OB-20]].</td>
+            <td>A signed Assertion in <a data-cite="RFC7515#section-3.1">JWS Compact JWS Serialization format.</a></td>
           </tr>
         </tbody>
       </table>
@@ -946,12 +951,12 @@ Link:
           <tbody>
             <tr>
               <td>Description</td>
-              <td>Fetch Assertions for the supplied parameters and authentication token. The result parameter MUST be a
-                list of zero or more matching Assertions which may be Open Badges 2.0 Assertion documents or
-                <a href="#api-signedbadge">Signed Badges</a>.
-                There SHOULD be only one result for a particular requested ID as the IDs are intended to be
-                globally unique. The Host SHOULD return Assertions ordered by last update, descending and SHOULD return
-                only Assertions updated after the timestamp requested if supplied.</td>
+              <td>Fetch Assertions for the supplied parameters and authentication token. The response envelope
+                contains a list of zero or more matching signed Assertions and a list of zero or more matching 
+                unsigned assertions. There SHOULD be only one assertion (signed or unsigned) for any particular
+                assertion ID as the IDs are intended to be globally unique. The Host SHOULD return Assertions
+                (signed and unsigned) ordered by last update, descending and SHOULD return only Assertions 
+                (signed and unsigned) updated after the timestamp requested if supplied.</td>
             </tr>
             <tr>
               <td>Query Parameters</td>
@@ -1045,8 +1050,7 @@ Link:
           <tbody>
             <tr>
               <td>Description</td>
-              <td>Create or update an Assertion. Multiple Assertions are not allowed. Data MUST be a list exactly one
-                Assertion long. JWS-signed Assertions must be represented in the JSON serialization option.</td>
+              <td>Create or update an Assertion. The posted data MUST be an <a href="#api-assertionpayload">Assertion Payload</a>.</td>
             </tr>
             <tr>
               <td>Responses</td>
@@ -1111,8 +1115,8 @@ Link:
             <tr>
               <td>Description</td>
               <td>Fetch the profile for the supplied authentication token. For a successful result, the Host MUST return
-                exactly one entry in the results list that is a valid OB Profile instance. Multiple values MAY be
-                present for each of the profile identifier properties other than "id": email, url, and telephone.</td>
+                a valid OB Profile instance.
+              </td>
             </tr>
             <tr>
               <td>Responses</td>
@@ -1263,7 +1267,7 @@ Link:
               <td><code>assertions</code></td>
               <td>No</td>
               <td>
-                The matching Assertions. The total number of assertions and signed assertions should not exceed the
+                The matching unsigned Assertions. The total number of unsigned and signed assertions should not exceed the
                 <a href="#api-envelope-pagination">pagination limit</a>. Not required if there are no unsigned assertions.
               </td>
             </tr>
@@ -1271,8 +1275,8 @@ Link:
               <td><code>signedAssertions</code></td>
               <td>No</td>
               <td>
-                The matching <a href="#epi-signedbadge">SignedBadge</a> objects. The total number of assertions and signed
-                assertions should not exceed the
+                The matching signed Assertions in <a data-cite="RFC7515#section-3">JWS Compact Serializion</a> format. 
+                The total number of unsigned and signed assertions should not exceed the
                 <a href="#api-envelope-pagination">pagination limit</a>. Not required if there are no signed assertions.
               </td>
             </tr>
@@ -1294,12 +1298,7 @@ Link:
         }
     ],
     "signedAssertions": [
-        {
-          "@context": "https://purl.imsglobal.org/spec/ob/v2p1/ob_v2p1.jsonld"
-          "id": "urn:uuid:3d339b63-cab3-4951-a574-8faf45d1b802",
-          "type": "SignedBadge",
-          "compactJws": "eyJhbGciOiJSUzI1NiJ9.ew0KICAiQGNvbnRleHQiOiAiaHR0cHM6Ly93M2lkLm9yZy9vcGVuYmFkZ2VzL3YyIiwNCiAgInR5cGUiOiAiQXNzZXJ0aW9uIiwNCiAgImlkIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3RpY3MtYmFkZ2UuanNvbiIsDQogICJyZWNpcGllbnQiOiB7DQogICAgInR5cGUiOiAiZW1haWwiLA0KICAgICJoYXNoZWQiOiB0cnVlLA0KICAgICJzYWx0IjogImRlYWRzZWEiLA0KICAgICJpZGVudGl0eSI6ICJzaGEyNTYkYzdlZjg2NDA1YmE3MWI4NWFjZDhlMmU5NTE2NmM0YjExMTQ0ODA4OWYyZTE1OTlmNDJmZTFiYmE0NmU4NjVjNSINCiAgfSwNCiAgImltYWdlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3QtYmFkZ2UucG5nIiwNCiAgImV2aWRlbmNlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3Qtd29yay5odG1sIiwNCiAgImlzc3VlZE9uIjogIjIwMTYtMTItMzFUMjM6NTk6NTlaIiwNCiAgImJhZGdlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvcm9ib3RpY3MtYmFkZ2UuanNvbiIsDQogICJ2ZXJpZnkiOiB7DQogICAgInR5cGUiOiAiU2lnbmVkQmFkZ2UiLA0KICAgICJjcmVhdG9yIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvcHVibGljS2V5Ig0KICB9DQp9.Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg"
-        }
+        "eyJhbGciOiJSUzI1NiJ9.ew0KICAiQGNvbnRleHQiOiAiaHR0cHM6Ly93M2lkLm9yZy9vcGVuYmFkZ2VzL3YyIiwNCiAgInR5cGUiOiAiQXNzZXJ0aW9uIiwNCiAgImlkIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3RpY3MtYmFkZ2UuanNvbiIsDQogICJyZWNpcGllbnQiOiB7DQogICAgInR5cGUiOiAiZW1haWwiLA0KICAgICJoYXNoZWQiOiB0cnVlLA0KICAgICJzYWx0IjogImRlYWRzZWEiLA0KICAgICJpZGVudGl0eSI6ICJzaGEyNTYkYzdlZjg2NDA1YmE3MWI4NWFjZDhlMmU5NTE2NmM0YjExMTQ0ODA4OWYyZTE1OTlmNDJmZTFiYmE0NmU4NjVjNSINCiAgfSwNCiAgImltYWdlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3QtYmFkZ2UucG5nIiwNCiAgImV2aWRlbmNlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3Qtd29yay5odG1sIiwNCiAgImlzc3VlZE9uIjogIjIwMTYtMTItMzFUMjM6NTk6NTlaIiwNCiAgImJhZGdlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvcm9ib3RpY3MtYmFkZ2UuanNvbiIsDQogICJ2ZXJpZnkiOiB7DQogICAgInR5cGUiOiAiU2lnbmVkQmFkZ2UiLA0KICAgICJjcmVhdG9yIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvcHVibGljS2V5Ig0KICB9DQp9.Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg"
     ]
 }
           </pre>
@@ -1352,7 +1351,7 @@ Link:
               <td><code>profile</code></td>
               <td>Yes</td>
               <td>
-                The matching Profile in an array with exactly one element.
+                The matching Profile.
               </td>
             </tr>
           </tbody>
@@ -1365,16 +1364,14 @@ Link:
         "statusText": "OK"
     },
 
-    "profile": [
-        {
-            "@context": "https://w3id.org/openbadges/v2",
-            "id": "https://host.example.com/profile/12345",
-            "type": "Profile",
-            "name": "John Appleseed ",
-            "url": "https://example.com",
-            "email": "john@example.com"
-        }
-    ]
+    "profile": {
+        "@context": "https://w3id.org/openbadges/v2",
+        "id": "https://host.example.com/profile/12345",
+        "type": "Profile",
+        "name": "John Appleseed ",
+        "url": "https://example.com",
+        "email": "john@example.com"
+    }
 }
           </pre>
       </section>
@@ -1398,7 +1395,7 @@ Link:
               <td><code>profile</code></td>
               <td>Yes</td>
               <td>
-                The updated Profile in an array with exactly one element.
+                The updated Profile.
               </td>
             </tr>
           </tbody>
@@ -1411,16 +1408,14 @@ Link:
         "statusText": "OK"
     },
 
-    "profile": [
-        {
-            "@context": "https://w3id.org/openbadges/v2",
-            "id": "https://host.example.com/profile/12345",
-            "type": "Profile",
-            "name": "John Appleseed ",
-            "url": "https://example.com",
-            "email": "john@example.com"
-        }
-    ]
+    "profile": {
+        "@context": "https://w3id.org/openbadges/v2",
+        "id": "https://host.example.com/profile/12345",
+        "type": "Profile",
+        "name": "John Appleseed ",
+        "url": "https://example.com",
+        "email": "john@example.com"
+    }
 }
           </pre>
       </section>

--- a/ob_v2p1/ob-spec-v2p1.html
+++ b/ob_v2p1/ob-spec-v2p1.html
@@ -811,9 +811,35 @@ grant_type=authorization_code
         <code>status</code> property and one or more result properties. The result property name(s) and data types 
         are defined in the <a href="#api-responses">Responses</a> section for each endpoint.
       </p>
+      <section id="api-envelope-status">
+        <h4>Status</h4>
+        <p>The "status" property MUST appear on all responses.</p>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>error</td>
+              <td>A nullable string and the human-readable message describing the problem.</td>
+            </tr>
+            <tr>
+              <td>statusCode</td>
+              <td>The HTTP status code of the response.</td>
+            </tr>
+            <tr>
+              <td>statusText</td>
+              <td>A string matching one of the enumerated and allowed values for the given endpoint.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
       <section id="api-envelope-pagination">
         <h4>Pagination</h4>
-        <p>Pagination is controlled by two query string parameters appended to the request.</p>
+        <p>Pagination of results is controlled by two query string parameters appended to the request.</p>
         <ul>
           <li><code>limit</code> - the number of results to return</li>
           <li><code>offset</code> - the index of the first record to return (zero indexed)</li>
@@ -860,36 +886,6 @@ Link:
 &lt;https://host.example.com/v1/assertions?limit=10&offset=0&gt;; rel="first",
 &lt;https://host.example.com/v1/assertions?limit=10&offset=0&gt;; rel="prev"
           </pre>
-      </section>
-      <section id="api-envelope-status">
-        <h4>Status</h4>
-        <p>The "status" property MUST appear on all responses.</p>
-        <table>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>error</td>
-              <td>A nullable string and the human-readable message describing the problem.</td>
-            </tr>
-            <tr>
-              <td>statusCode</td>
-              <td>The HTTP status code of the response.</td>
-            </tr>
-            <tr>
-              <td>statusText</td>
-              <td>A string matching one of the enumerated and allowed values for the given endpoint.</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
-      <section id="api-envelope-results">
-        <h4>Results</h4>
-        <p>A list of zero or more documents responsive to the request.</p>
       </section>
     </section>
     <section id="api-signedbadge">

--- a/ob_v2p1/ob-spec-v2p1.html
+++ b/ob_v2p1/ob-spec-v2p1.html
@@ -1269,7 +1269,7 @@ Link:
               <td>No</td>
               <td>
                 The matching Assertions. The total number of assertions and signed baddges should not exceed the
-                [pageination limit](#api-envelope-pagination). Not required if the request was not processed successfully.
+                [pageination limit](#api-envelope-pagination). Not required if there are no unsigned assertions.
               </td>
             </tr>
             <tr>
@@ -1278,7 +1278,7 @@ Link:
               <td>
                 The matching <a href="#epi-signedbadge">SignedBadge</a> objects. The total number of assertions and signed
                 assertions should not exceed the
-                [pageination limit](#api-envelope-pagination). Not required if the request was not processed successfully.
+                [pageination limit](#api-envelope-pagination). Not required if there are no signed assertions.
               </td>
             </tr>
           </tbody>
@@ -1355,10 +1355,9 @@ Link:
             </tr>
             <tr>
               <td><code>profile</code></td>
-              <td>No</td>
+              <td>Yes</td>
               <td>
-                The matching Profile in an array with exactly one element. Not required if the request was not
-                processed successfully.
+                The matching Profile in an array with exactly one element.
               </td>
             </tr>
           </tbody>
@@ -1402,10 +1401,9 @@ Link:
             </tr>
             <tr>
               <td><code>profile</code></td>
-              <td>No</td>
+              <td>Yes</td>
               <td>
-                The updated Profile in an array with exactly one element. Not required if the request was not
-                processed successfully.
+                The updated Profile in an array with exactly one element.
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
PR fixes #241, #242, and #245

- Modified GET /assertions response envelope to contain two result arrays: "assertions", and "signedBadges".
- All other responses remain unchanged.

Note: Now that the responses to GET /assertions, GET /profile, and POST /profile have different shapes, do you want to change the results property for GET /profile and POST /profile to a singular "profile" property? For example,
```
{
  "status": {STATUS...},
  "profile": {PROFILE...}
}
```