### PR TITLE
Convert 2.0 document set to IMS Respec

### DIFF
--- a/ob_v2p0/baking/ob-bake-errata-v1p0.html
+++ b/ob_v2p0/baking/ob-bake-errata-v1p0.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <script src='https://purl.imsglobal.org/spec/respec-ims-default.js' async class='remove'></script>
+    <script src='../shared/localBiblio.js' class="remove"></script>
+    <script src='../shared/contributors.js' class="remove"></script>
+    <script src='../shared/iprs.js' class="remove"></script>
+    <script class='remove'>
+        var respecConfig = {
+            mainSpecTitle: "Open Badges Specification",
+            mainSpecBiblioKey: "OB-20",
+            specTitle: "Open Badges Baking Specification Errata",
+            shortName: "ob/baking",
+            specStatus: "IMS Final Release",
+            specDate: "April 16, 2019",
+            specVersion: "1.0",
+            specNature: "normative",
+            specType: "errata",
+            format: "markdown",
+            maxTocLevel: "2",
+            skipCertGuideConformanceRef: false,
+            contributors: _contributors,
+            iprs: _iprs,
+
+            /*
+            * Define a temporary localBiblio to resolve references to spec documents that don't exist
+            * on the IMS purl server. Once the documents exist, remove this localBiblio.
+            */
+            localBiblio: _localBiblio
+        };
+    </script>
+</head>
+
+<body>
+    <section class="introductory" id="abstract">
+        <script class="transclude" src="../shared/ob-abstract.md" data-id="abstract"></script>
+    </section>
+
+    <section>
+        <h2>Introduction</h2>
+
+        <section id="document-set">
+            <script class="transclude" src="../shared/ob-documents.md" data-id="documents"></script>
+        </section>
+    </section>
+
+    <script class="transclude" src="ob-bake-errata-v1p0.md" data-id="md"></script>
+
+    <section class="appendix informative" id="revisionhistory">
+        <h1>Revision History</h1>
+        <section>
+            <h3>Version History</h3>
+            <table title="Revision History">
+                <thead>
+                    <tr>
+                        <th>Version No.</th>
+                        <th>Release Date</th>
+                        <th>Comments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Version 2.0 IMS Final Release</td>
+                        <td>April 12, 2018</td>
+                        <td>First release.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+
+</html>

--- a/ob_v2p0/baking/ob-bake-errata-v1p0.md
+++ b/ob_v2p0/baking/ob-bake-errata-v1p0.md
@@ -1,0 +1,7 @@
+var md = `
+
+## Errata
+
+There is no errata.
+
+`;

--- a/ob_v2p0/baking/ob-bake-v1p0.html
+++ b/ob_v2p0/baking/ob-bake-v1p0.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <script src='https://purl.imsglobal.org/spec/respec-ims-default.js' async class='remove'></script>
+    <script src='../shared/localBiblio.js' class="remove"></script>
+    <script src='../shared/contributors.js' class="remove"></script>
+    <script src='../shared/iprs.js' class="remove"></script>
+    <script class='remove'>
+        var respecConfig = {
+            mainSpecTitle: "Open Badges Specification",
+            mainSpecBiblioKey: "OB-20",
+            specTitle: "Open Badges Baking Specification",
+            shortName: "ob/baking",
+            specStatus: "IMS Final Release",
+            specDate: "April 16, 2018",
+            specVersion: "1.0",
+            specNature: "normative",
+            specType: "spec",
+            format: "markdown",
+            maxTocLevel: "3",
+            skipCertGuideConformanceRef: false,
+            contributors: _contributors,
+            iprs: _iprs,
+
+            /*
+            * Define a temporary localBiblio to resolve references to spec documents that don't exist
+            * on the IMS purl server. Once the documents exist, remove this localBiblio.
+            */
+            localBiblio: _localBiblio
+        };
+    </script>
+</head>
+
+<body>
+    <section class="introductory" id="abstract">
+        <script class="transclude" src="../shared/ob-abstract.md" data-id="abstract"></script>
+    </section>
+
+    <section>
+        <h2>Introduction</h2>
+
+        <section id="conformance">
+            <h3>Conformance and Certification</h3>
+        </section>
+
+        <section id="document-set">
+            <script class="transclude" src="../shared/ob-documents.md" data-id="documents"></script>
+        </section>
+    </section>
+
+    <script class="transclude" src="ob-bake-v1p0.md" data-id="md"></script>
+
+    <section class="appendix informative" id="revisionhistory">
+        <h1>Revision History</h1>
+        <section>
+            <h3>Version History</h3>
+            <table title="Revision History">
+                <thead>
+                    <tr>
+                        <th>Version No.</th>
+                        <th>Release Date</th>
+                        <th>Comments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Version 1.0 Final</td>
+                        <td>April 16, 2018</td>
+                        <td>IMS Final Release, no material changes since last release.</td>
+                    </tr>
+                    <tr>
+                        <td>Version 1.0</td>
+                        <td>February 13, 2017</td>
+                        <td>
+                            <ul>
+                                <li>Update SVG example to use Open Badges 2.0 syntax</li>
+                                <li>Fix typo in introduction</li>
+                            </ul>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Version 1.0</td>
+                        <td>November 5, 2013</td>
+                        <td>
+                            <ul>
+                                <li>Support for full assertions added</li>
+                                <li>Support for signed badges added</li>
+                                <li>Support for SVGs added</li>
+                                <li>PNG baking now uses <code>iTXt chunk</code></li>
+                            </ul>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Pre-release</td>
+                        <td></td>
+                        <td>
+                            <ul>
+                                <li>Only PNGs supported: <code>tEXt</code> chunk used with keyboard
+                                    <code>openbadges</code></li>
+                                <li>Only hosted badges supported</li>
+                                <li>Hosted URL embedded in PNG</li>
+                            </ul>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+
+</html>

--- a/ob_v2p0/baking/ob-bake-v1p0.md
+++ b/ob_v2p0/baking/ob-bake-v1p0.md
@@ -1,0 +1,114 @@
+var md=`
+
+# Badge Baking
+
+## What Is Badge Baking?
+
+Open Badges may be transmitted as image files with badge Assertions encoded within. This allows Open Badges to be portable wherever image files may be stored or displayed. Each <a data-cite="OB-20#assertion"><code>Assertion</code></a> as defined in [[[OB-20]]] expresses verifiable information about an individual's achievement. 
+
+Badge Baking is the process of taking an Assertion and embedding it into the badge image, so that when a user displays a badge on a page, software that is OpenBadges-aware can automatically extract that Assertion data and perform the checks necessary to see if a person legitimately earned the badge. The <a data-cite="OB-20#badgeclass"><code>BadgeClass</code></a> image must be in either PNG or SVG format in order to support baking.
+
+## Technical Details
+
+### PNGs
+
+This section describes the method of baking and extracting OpenBadges in PNG image files as defined by [[[PNG]]].
+
+#### Baking
+
+An <a data-cite="PNG#11iTXt"><code>iTXt</code></a> chunk should be inserted into the PNG with keyword <code>openbadges</code>. The text can either be a signed badge assertion or the raw JSON for the OpenBadges assertion. Compression MUST NOT be used. At the moment, *language tag* and *translated keyword* have no semantics related to badge baking.
+
+An example of creating a chunk (assuming an <code>iTXt</code> constructor):
+
+<pre>
+var chunk = new iTXt({
+  keyword: 'openbadges',
+  compression: 0,
+  compressionMethod: 0,
+  languageTag: '',
+  translatedKeyword: '',
+  text: signature || JSON.stringify(assertion)
+})
+</pre>
+
+An <code>iTXt</code> chunk with the keyword <code>openbadges</code> MUST NOT appear in a PNG more than once. When baking a badge that already contains OpenBadges data, the implementor may choose whether to pass the user an error or overwrite the existing chunk.
+
+#### Extracting
+
+Parse the PNG datastream until the first <a data-cite="PNG#11iTXt"><code>iTXt</code></a> chunk is found with the keyword <code>openbadges</code>. The rest of the stream can be safely discarded. The text portion of the iTXt will either be the JSON representation of an OpenBadges assertion or a signature.
+
+#### Legacy PNGs
+
+The pre-specified behavior of badge baking worked differently. Instead of baking the whole assertion or signature into an <code>iTXt:openbadges</code> chunk, the URL pointing to the hosted assertion was baked into a <code>tEXt:openbadges</code> chunk. In order to get the full assertion, an additional HTTP request must be made after extracting the URL from the <code>tEXt</code> chunk.
+
+### SVGs
+
+This section describes the method of baking and extracting OpenBadges in SVG images as defined by [[[SVG11]]].
+
+#### Baking
+
+First, add an <code>xmlns:openbadges</code> attribute to the <code>&lt;svg></code> tag with the value "http://openbadges.org". Directly after the <code>&lt;svg></code> tag, add an <code>&lt;openbadges:assertion></code> tag with a <code>verify</code> attribute. The value of <code>verify</code> should either be a signed OpenBadges assertion or the URL from <code>verify.url</code> in the badge assertion.
+
+If a signature is being baked, no tag body is necessary and the tag should be self closing.
+
+If an assertion is being baked, the JSON representation of the assertion should go into the body of the tag, wrapped in <code>&lt;![CDATA[...]]></code>.
+
+An example of a well baked SVG with a hosted assertion:
+
+<pre>
+&lt;?xml version="1.0" encoding="UTF-8"?>
+&lt;svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:openbadges="http://openbadges.org"
+     viewBox="0 0 512 512">
+  &lt;openbadges:assertion verify="https://example.org/assertions/123">
+    &lt;![CDATA[
+	   {
+	     "@context": "https://w3id.org/openbadges/v2",
+	     "id": "https://example.org/assertions/123",
+	     "type": "Assertion",
+	     "recipient": {
+	       "type": "email",
+	       "identity": "alice@example.org"
+	     },
+	     "issuedOn": "2016-12-31T23:59:59+00:00",
+	     "verification": {
+	       "type": "hosted"
+	     },
+	     "badge": {
+	       "id": "https://example.org/badges/5",
+		   "type": "BadgeClass",	       
+	       "name": "3-D Printmaster",
+	       "description": "This badge is awarded …",
+	       "image": "https://example.org/badges/5/image",
+	       "criteria": {
+	         "narrative": "Students are tested on …"
+	       },
+	       "issuer": {
+	         "id": "https://example.org/issuer",
+	         "type": "Profile",
+	         "name": "Example Maker Society",
+	         "url": "https://example.org",
+	         "email": "contact@example.org",
+	         "verification": {
+	            "allowedOrigins": "example.org"
+	         }
+	       }
+	     }
+	   }
+    ]]>
+  &lt;/openbadges:assertion>
+
+  <rest-of-document...>
+&lt;/svg>
+</pre>
+
+There MUST be only one <code>&lt;openbadges:assertion></code> tag in an SVG. When baking a badge that already contains OpenBadges data, the implementor may choose whether to pass the user an error or overwrite the existing tag.
+
+#### Extracting
+
+Parse the SVG until you reach the first <code>&lt;openbadges:assertion></code> tag. The rest of the SVG data can safely be discarded.
+
+If the tag has no body, the <code>verify</code> attribute will contain the signature of the badge. If there is a body, it will be the JSON representation of a badge assertion.
+
+<div></div>
+`;

--- a/ob_v2p0/cert/ob-cert-errata-v2p0.html
+++ b/ob_v2p0/cert/ob-cert-errata-v2p0.html
@@ -11,11 +11,11 @@
         var respecConfig = {
             mainSpecTitle: "Open Badges Specification",
             mainSpecBiblioKey: "OB-20",
-            specTitle: "Open Badges Baking Specification Errata",
-            shortName: "ob/baking",
+            specTitle: "Open Badges Conformance and Certification Guide Errata",
+            shortName: "ob/cert",
             specStatus: "IMS Final Release",
-            specDate: "April 16, 2018",
-            specVersion: "1.0",
+            specDate: "April 12, 2018",
+            specVersion: "2.0",
             specNature: "normative",
             specType: "errata",
             format: "markdown",
@@ -46,7 +46,7 @@
         </section>
     </section>
 
-    <script class="transclude" src="ob-bake-errata-v1p0.md" data-id="md"></script>
+    <script class="transclude" src="ob-cert-errata-v2p0.md" data-id="md"></script>
 
     <section class="appendix informative" id="revisionhistory">
         <h1>Revision History</h1>

--- a/ob_v2p0/cert/ob-cert-errata-v2p0.md
+++ b/ob_v2p0/cert/ob-cert-errata-v2p0.md
@@ -1,0 +1,7 @@
+var md = `
+
+## Errata
+
+There is no errata.
+
+`;

--- a/ob_v2p0/cert/ob-cert-v2p0.html
+++ b/ob_v2p0/cert/ob-cert-v2p0.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <script src='https://purl.imsglobal.org/spec/respec-ims-default.js' async class='remove'></script>
+    <script src='../shared/localBiblio.js' class="remove"></script>
+    <script src='../shared/contributors.js' class="remove"></script>
+    <script src='../shared/iprs.js' class="remove"></script>
+    <script class='remove'>
+        var respecConfig = {
+            mainSpecTitle: "Open Badges Specification",
+            mainSpecBiblioKey: "OB-20",
+            specTitle: "Open Badges Conformance and Certification Guide",
+            shortName: "ob/cert",
+            specStatus: "IMS Final Release",
+            specDate: "April 12, 2018",
+            specVersion: "2.0",
+            specNature: "normative",
+            specType: "spec",
+            format: "markdown",
+            maxTocLevel: "3",
+            skipCertGuideConformanceRef: false,
+            contributors: _contributors,
+            iprs: _iprs,
+
+            /*
+            * Define a temporary localBiblio to resolve references to spec documents that don't exist
+            * on the IMS purl server. Once the documents exist, remove this localBiblio.
+            */
+            localBiblio: _localBiblio
+        };
+    </script>
+</head>
+
+<body>
+    <section class="introductory" id="abstract">
+        <script class="transclude" src="../shared/ob-abstract.md" data-id="abstract"></script>
+    </section>
+
+    <section>
+        <h2>Introduction</h2>
+
+        <section id="conformance">
+            <h3>Conformance and Certification</h3>
+        </section>
+
+        <section id="document-set">
+            <script class="transclude" src="../shared/ob-documents.md" data-id="documents"></script>
+        </section>
+        
+        <section id="terminology">
+                <script class="transclude" src="../shared/ob-terms.md" data-id="terms"></script>
+        </section>    
+    </section>
+
+    <script class="transclude" src="ob-cert-v2p0.md" data-id="md"></script>
+
+    <section class="appendix informative" id="revisionhistory">
+        <h1>Revision History</h1>
+        <section>
+            <h3>Version History</h3>
+            <table title="Revision History">
+                <thead>
+                    <tr>
+                        <th>Version No.</th>
+                        <th>Release Date</th>
+                        <th>Comments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Version 2.0 IMS Final</td>
+                        <td>April 12, 2018</td>
+                        <td>Covers Issuer, Displayer, and Host conformance and certification.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+
+</html>

--- a/ob_v2p0/cert/ob-cert-v2p0.md
+++ b/ob_v2p0/cert/ob-cert-v2p0.md
@@ -1,0 +1,94 @@
+var md = `
+
+## Open Badges Conformance
+
+The goal of IMS certification for Open Badges is to ensure interoperable implementations of badging systems that generate and issue digital badges as well as those that host and display badges.
+
+IMS certification for Open Badges demands features and capabilities beyond those that are strictly required by the specification. These additional features are defined in this document. The specification is intentionally left very flexible to allow it to be used for many purposes. Gaining this certification is expected to be more difficult than simply meeting the minimum requirements for producing a valid Open Badge.
+
+Certification may be achieved in one or more of the following roles:
+
+* Issuer
+* Displayer
+* Host
+
+The roles and associated certification tests are defined below.
+
+### The Conformance Process
+
+The process for conformance testing role implementations of Open Badges includes the following:
+
+* Go to the [IMS Conformance Test Suite for Open Badges 2.0](https://www.imsglobal.org/open-badges-certification-suite) and follow the instructions to create and submit an application for conformance certification.
+
+To pass certification, you must take the following steps:
+
+* You must be an IMS Digital Credentials and Badges Alliance Member, an IMS Affiliate Member, or IMS Contributing Member. 
+* You must pass all the tests associated with the role you are applying for using the certification suite hosted on the IMS website. The roles and associated tests are specified below. 
+* The tests must be completed by a designated representative of the IMS member organization, and you must agree that there is no misrepresentation or manipulation of results in the submitted information.
+
+After IMS reviews your submitted information and notifies you that your application is approved, you can claim certification to Open Badges and display the IMS certified logo on your website and in your software. The [IMS Global Certified Products Directory](https://site.imsglobal.org/certifications) will list your conformance details.
+
+### Issuer Role Conformance
+
+An Open Badges **Issuer** is an application that allows for the creation of <a data-cite="OB-20#BadgeClass">BadgeClasses</a> and the subsequent delivery of <a data-cite="OB-20#Assertion">Assertions</a> to recipients that conform to the [[[OB-20]]]. Beginning with Open Badges 2.0, the candidate platform must issue a valid baked badge per the [[[OB-BAKE-10]]] and demonstrate how the badge is retrieved by the recipient.
+
+**Tests**
+
+1. Create a valid baked badge and issue it to the recipient <code>conformance@imsglobal.org</code>.
+2. Demonstrate through video the candidate platform's methodology for a recipient to retrieve their badge.
+
+### Displayer Role Conformance
+
+An Open Badges **Displayer** is an application that displays verified badges to viewers. Beginning with Open Badges 2.0, the candidate platform must display a minimum set of badge metadata and support viewer-initiated verification of a badge.
+
+**Tests**
+
+1. Demonstrate through separate videos that the platform allows viewers of badges to see the following data in three different badges. Note that IMS is not supplying these badges; you will have to supply them yourself.
+
+	**Badge 1**
+
+	1. <a data-cite="OB-20#BadgeClass">BadgeClass</a> <code>image</code>, <code>name</code>, <code>description</code>
+		* <a data-cite="OB-20#Profile">Issuer</a> <code>name</code>
+	3. <a data-cite="OB-20#Assertion">Assertion</a> <code>issuedOn</code> date
+	4. **Neither expired nor revoked**
+
+	**Badge 2**
+
+	1. <a data-cite="OB-20#BadgeClass">BadgeClass</a> <code>image</code>, <code>name</code>, <code>description</code>
+		* <a data-cite="OB-20#Profile">Issuer</a> <code>name</code>
+	3. <a data-cite="OB-20#Assertion">Assertion</a> <code>issuedOn</code> date
+	4. **Expired status** (display of expiration date optional)
+	5. Not revoked
+
+	**Badge 3**
+
+	1. <a data-cite="OB-20#BadgeClass">BadgeClass</a> <code>image</code>, <code>name</code>, <code>description</code>
+		* <a data-cite="OB-20#Profile">Issuer</a> <code>name</code>
+	3. <a data-cite="OB-20#Assertion">Assertion</a> <code>issuedOn</code> date
+	4. Not expired
+	5. **Revoked status** (display of revocation reason optional)
+
+2. Demonstrate through video that the platform allows viewers of badges to do one or both of the following:
+
+	1. Trigger verification of the badge and retrieve results verifying that the badge assertion is not expired, and not revoked.
+	2. Consume pre-existing verification information that includes the results and timestamp of latest verification.
+
+### Host Role Conformance
+
+An Open Badges **Host** is an application that can aggregate and publicly host <a data-cite="OB-20#Assertion">Assertions</a> for recipients. It also supports export of badges at user request. Beginning with Open Badges 2.0, the candidate platform must be able to import all formats of Open Badges as well as prove that badge metadata is not lost upon export of the badge.
+
+**Tests**
+
+1. Using the artifacts provided below, demonstrate through video the ability to import each of the provided artifacts (baked PNG badge, baked SVG badge, and Assertion URL). Note that the applicant may be required to create a fake account in the candidate platform.
+2. Using one of the badge formats provided below, demonstrate through video the full process of importing the badge into your platform, exporting it out of your platform, and then submitting that badge to IMS for diff comparison with the original.
+
+	*Note - the recipient identity in these badges is <code>conformance@imsglobal.org</code>*.
+
+	| Required Badge Format | Use this resource for the demonstrations |
+	| --------------------- | ---------------------------------------- |
+	| Baked badge (PNG) format | https://openbadgesvalidator.imsglobal.org/SampleResources/OB20-assertion1-conformance.png |
+	| Baked badge (SVG) format | https://openbadgesvalidator.imsglobal.org/SampleResources/OB20-assertion-conformance-servicelearning.svg |
+	| Assertion URL | https://badges.imsglobal.org/public/assertions/1geQXkWnQnW0BkWcO3jSPA.json?v=2_0 |
+
+<div></div>
+`;

--- a/ob_v2p0/examples/ob-examples.html
+++ b/ob_v2p0/examples/ob-examples.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <script src='https://purl.imsglobal.org/spec/respec-ims-default.js' async class='remove'></script>
+    <script src='../shared/localBiblio.js' class="remove"></script>
+    <script src='../shared/contributors.js' class="remove"></script>
+    <script src='../shared/iprs.js' class="remove"></script>
+    <script class='remove'>
+        var respecConfig = {
+            mainSpecTitle: "Open Badges Specification",
+            mainSpecBiblioKey: "OB-20",
+            specTitle: "Open Badges Examples",
+            shortName: "ob",
+            specDate: "April 12, 2018",
+            specNature: "informative",
+            specType: "doc",
+            format: "markdown",
+            maxTocLevel: "3",
+            contributors: _contributors,
+            iprs: _iprs,
+
+            /*
+            * Define a temporary localBiblio to resolve references to spec documents that don't exist
+            * on the IMS purl server. Once the documents exist, remove this localBiblio.
+            */
+            localBiblio: _localBiblio
+        };
+    </script>
+</head>
+
+<body>
+    <section class="introductory" id="abstract">
+        <script class="transclude" src="../shared/ob-abstract.md" data-id="abstract"></script>
+    </section>
+
+    <section>
+        <h2>Introduction</h2>
+
+        <section id="conformance">
+            <h3>Conformance and Certification</h3>
+        </section>
+
+        <section id="document-set">
+            <script class="transclude" src="../shared/ob-documents.md" data-id="documents"></script>
+        </section>
+
+        <section id="terminology">
+            <script class="transclude" src="../shared/ob-terms.md" data-id="terms"></script>
+        </section>
+    </section>
+
+    <script class="transclude" src="ob-examples.md" data-id="md"></script>
+
+    <section class="appendix informative" id="revisionhistory">
+        <h1>Revision History</h1>
+        <section>
+            <h3>Version History</h3>
+            <table title="Revision History">
+                <thead>
+                    <tr>
+                        <th>Release Date</th>
+                        <th>Comments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>April 12, 2018</td>
+                        <td>No material changes since last release.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+
+</html>

--- a/ob_v2p0/examples/ob-examples.md
+++ b/ob_v2p0/examples/ob-examples.md
@@ -1,0 +1,507 @@
+var md = `
+
+## Examples of Core Open Badges objects
+Information is divided between badge objects that describe an individual earner's accomplishment (<a data-cite="OB-20#Assertion">Assertion</a>), the general features of the achievement (<a data-cite="OB-20#BadgeClass">BadgeClass</a>), and the entity or organization issuing the badge (<a data-cite="OB-20#Profile">Issuer</a>).
+
+
+<h3 id="Assertion">Assertion Example</h3>
+
+(<a data-cite="OB-20#Assertion">definition</a>)
+
+An example of a badge Assertion using the <code>hosted</code> verification method. This JSON object is "baked" into a badge image (optionally linked at the Assertion's <code>image</code> property) and also hosted at the location specified by the <code>@id</code> and <code>verify.url</code> properties.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "type": "Assertion",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "recipient": {
+    "type": "email",
+    "hashed": true,
+    "salt": "deadsea",
+    "identity": "sha256$c7ef86405ba71b85acd8e2e95166c4b111448089f2e1599f42fe1bba46e865c5"
+  },
+  "image": "https://example.org/beths-robot-badge.png",
+  "evidence": "https://example.org/beths-robot-work.html",
+  "issuedOn": "2016-12-31T23:59:59Z",
+  "expires": "2017-06-30T23:59:59Z",
+  "badge": "https://example.org/robotics-badge.json",
+  "verification": {
+    "type": "hosted"
+  }
+}
+</pre>
+
+
+<h3 id="BadgeClass">BadgeClass Example</h3>
+
+(<a data-cite="OB-20#BadgeClass">definition</a>)
+
+The BadgeClass is hosted at the URI identified in associated Assertions' <code>badge</code> property.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "type": "BadgeClass",
+  "id": "https://example.org/robotics-badge.json",
+  "name": "Awesome Robotics Badge",
+  "description": "For doing awesome things with robots that people think is pretty great.",
+  "image": "https://example.org/robotics-badge.png",
+  "criteria": "https://example.org/robotics-badge.html",
+  "tags": ["robots", "awesome"],
+  "issuer": "https://example.org/organization.json",
+  "alignment": [
+    { "targetName": "CCSS.ELA-Literacy.RST.11-12.3",
+      "targetUrl": "http://www.corestandards.org/ELA-Literacy/RST/11-12/3",
+      "targetDescription": "Follow precisely a complex multistep procedure when carrying out experiments, taking measurements, or performing technical tasks; analyze the specific results based on explanations in the text.",
+      "targetCode": "CCSS.ELA-Literacy.RST.11-12.3"
+    },
+    { "targetName": "Problem-Solving",
+      "targetUrl": "https://learning.mozilla.org/en-US/web-literacy/skills#problem-solving",
+      "targetDescription": "Using research, analysis, rapid prototyping, and feedback to formulate a problem and develop, test, and refine the solution/plan.",
+      "targetFramework": "Mozilla 21st Century Skills"
+    }
+  ]
+}
+</pre>
+
+**Notes**:
+
+* The JSON-LD data model treats <code>"property": ["value"]</code> as equivalent to <code>"property": "value"</code>. An example of this is that <code>alignment</code> takes one or multiple AlignmentObjects. If only one value is present, it may or may not be included in <code>[]</code>. Not all of the Open Badges properties accept multiple values. For instance, <code>issuer</code> may only have one value.
+* Many <code>@id</code>-type fields may have a property that appears as an IRI/URI or as an embedded JSON object (with <code>{}</code>). For example, <code>issuer</code> may include an embedded copy of the issuer Profile. Verifiers should fetch the issuer Profile from its HTTP <code>id</code> and in most cases treat the hosted value as the most up-to-date representation. In the case of signed-verification Assertions, an embedded <code>BadgeClass</code> or issuer <code>Profile</code> can be interpreted to be the value claimed at the time of issue, though <code>publicKeys</code> referenced in an embedded issuer <code>Profile</code> should not be trusted to belong to the issuer without checking the hosted Profile.
+
+
+<h3 id="Profile">Profile (Issuer) Example</h3>
+
+(<a data-cite="OB-20#Profile">definition</a>)
+
+Metadata about the issuer is defined in JSON at a URL/IRI defined by the BadgeClass's <code>issuer</code> property.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "type": "Issuer",
+  "id": "https://example.org/organization.json",
+  "name": "An Example Badge Issuer",
+  "image": "https://example.org/logo.png",
+  "url": "https://example.org",
+  "email": "contact@example.org",
+  "publicKey": "https://example.org/publicKey.json",
+  "revocationList": "https://example.org/revocationList.json"
+}
+</pre>
+
+
+<h3 id="Extensions">Extension Examples</h3>
+
+(<a data-cite="OB-20#Extensions">definition</a>)
+
+Extensions are formal sets of properties issuers and platforms add to the Open Badges Vocabulary. A number of community-developed extensions are published on the [[[OB-EXTENSIONS]]] page with embedded examples of each.
+
+## Open Badges in Linked Data
+Because Open Badges are Linked Data objects often hosted at HTTP IRIs, we can use the methods of identifying connections using Badge Objects can identify their connected resources either by their string IRI or by embedding a copy of the related document into the source document. For example, an Assertion may include its BadgeClass definition for portability instead of just linking to the URI of the BadgeClass object. Here, the BadgeClass and its issuer Profile record have been included in the Assertion. Each has its "id" property set to the URI where it is published, the unique identifier for that object. Displayer platforms can use that value to index these records. 
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "type": "Assertion",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "recipient": {
+    "type": "email",
+    "hashed": true,
+    "salt": "deadsea",
+    "identity": "sha256$c7ef86405ba71b85acd8e2e95166c4b111448089f2e1599f42fe1bba46e865c5"
+  },
+  "issuedOn": "2016-12-31T23:59:59Z",
+  "badge": {
+    "id": "https://example.org/robotics-badge.json",
+    "type": "BadgeClass",
+    "name": "Awesome Robotics Badge",
+    "description": "For doing awesome things with robots that people think is pretty great.",
+    "image": "https://example.org/robotics-badge.png",
+    "criteria": "https://example.org/robotics-badge.html",
+    "issuer": {
+      "type": "Profile",
+      "id": "https://example.org/organization.json",
+      "name": "An Example Badge Issuer",
+      "image": "https://example.org/logo.png",
+      "url": "https://example.org",
+      "email": "steved@example.org",
+    }
+  },
+  "verification": {
+    "type": "hosted"
+  }
+}
+</pre>
+
+**Notes**:
+* In this example, the <code>badge</code> property in the Assertion is expanded to offer a full BadgeClass record, but not all identifying URIs (<code>@id</code>-type fields) are represented here as this type of expanded document. For example, <code>criteria</code> and <code>image</code> properties just use a URI here instead of taking advantage of linked data classes for these items in the Specification. You may publish badge objects with a mix of URI references and expanded document formats that have indexable <code>id</code>s. Properties that in v1.1 expected a String URI datatype may now encounter a <code>{}</code> object containing an <code>id</code> property and other metadata. All such properties are now listed in the spec as expecting an @id (linked data subject) expecting the IRI or document representation of a certain data class.
+* Because the properties describing the BadgeClass and issuer Profile are within the same context that's included at the top of the JSON-LD document, you don't need to include a new reference to the "@context" each time.
+* Because this Assertion uses "hosted" verification, and there is no cryptographic signature to verify that the full document here is the exact one published by the issuer, verifier and displayer platforms will likely discard the embedded BadgeClass and issuer Profile here and replace them with the values discovered at their <code>id</code> URIs, because only those hosted documents can be trusted to be the creation of the issuer. If the Assertion uses "signed" verification, the validator may accept the embedded values as the intended BadgeClass and issuer Profile, and if they have multiple records for those entities that use the declared <code>id</code>, the validator may choose how to index and present that information. Issuers should change the <code>id</code>s of their BadgeClasses when they make edits if they wish the edits to essentially be understood as a different achievement than the one published under the original <code>id</code>.
+
+## Additional Vocabulary Classes Examples
+While the Assertion, BadgeClass, and Profile are the minimal set of JSON-LD resources necessary for a valid badge, there are several secondary data classes that extend the usefulness, security, and portability of Open Badges. The examples below are often abbreviated to highlight a specific feature, so not all examples contain all the required properties to constitute a valid Badge Object of their type.
+
+
+<h3 id="SignedBadge">Signed Badges Example</h3>
+
+(<a data-cite="OB-20#SignedBadge">definition</a>)
+
+[[[RFC7515]]] is a signature method accepted for Open Badges objects. A JSON Web Signature (JWS) for a signed Assertion is made up of three components, packaged as a string with <code>.</code>s used as separators. (Space has been added here around the <code>.</code> separators for clarity.) This example is not a valid JWS, as the referenced key on example.org does not exist.
+<pre>
+eyJhbGciOiJSUzI1NiJ9
+.
+ew0KICAiQGNvbnRleHQiOiAiaHR0cHM6Ly93M2lkLm9yZy9vcGVuYmFkZ2VzL3YyIiwNCiAgInR5cGUiOiAiQXNzZXJ0aW9uIiwNCiAgImlkIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3RpY3MtYmFkZ2UuanNvbiIsDQogICJyZWNpcGllbnQiOiB7DQogICAgInR5cGUiOiAiZW1haWwiLA0KICAgICJoYXNoZWQiOiB0cnVlLA0KICAgICJzYWx0IjogImRlYWRzZWEiLA0KICAgICJpZGVudGl0eSI6ICJzaGEyNTYkYzdlZjg2NDA1YmE3MWI4NWFjZDhlMmU5NTE2NmM0YjExMTQ0ODA4OWYyZTE1OTlmNDJmZTFiYmE0NmU4NjVjNSINCiAgfSwNCiAgImltYWdlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3QtYmFkZ2UucG5nIiwNCiAgImV2aWRlbmNlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvYmV0aHMtcm9ib3Qtd29yay5odG1sIiwNCiAgImlzc3VlZE9uIjogIjIwMTYtMTItMzFUMjM6NTk6NTlaIiwNCiAgImJhZGdlIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvcm9ib3RpY3MtYmFkZ2UuanNvbiIsDQogICJ2ZXJpZnkiOiB7DQogICAgInR5cGUiOiAiU2lnbmVkQmFkZ2UiLA0KICAgICJjcmVhdG9yIjogImh0dHBzOi8vZXhhbXBsZS5vcmcvcHVibGljS2V5Ig0KICB9DQp9
+.
+Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg
+</pre>
+When base64 decoded this corresponds to the three JSON objects below for a signed 2.0 Open Badge:
+
+Header:
+<pre>
+{ "alg": "RS256" }
+</pre>
+Claims:
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "type": "Assertion",
+  "id": "urn:uuid:a953081a-4bbd-4927-9653-7219bca00e3b",
+  "recipient": {
+    "type": "email",
+    "hashed": true,
+    "salt": "deadsea",
+    "identity": "sha256$c7ef86405ba71b85acd8e2e95166c4b111448089f2e1599f42fe1bba46e865c5"
+  },
+  "evidence": "https://example.org/beths-robot-work.html",
+  "issuedOn": "2016-12-31T23:59:59Z",
+  "badge": "https://example.org/robotics-badge.json",
+  "verification": {
+    "type": "SignedBadge",
+    "creator": "https://example.org/publicKey.json"
+  }
+}
+</pre>
+Signature:
+<pre>
+Liv4CLviFH20_6RciUWf-jrUvMAecxT4KZ_gLHAeT_chrsCvBEE1uwgtwiarIs9acFfMi0FJzrGye6mhdHf3Kjv_6P7BsG3RPkYgK6-5i9uZv4QAIlvfNclWAoWUt4j0_Kip2ftzzWwc5old01nJRtudZHxo5eGosSPlztGRE9G_g_cTj32tz3fG92E2azPmbt7026G91rq80Mi-9c4bZm2EgrcwNBjO0p1mbKYXLIAAkOMuJZ_8S4Go8S0Sg3xC6ZCn03zWuXCP6bdY_jJx2BpmvqC3H55xWIU8p5c9RxI8YifPMmJq8ZQhjld0pl-L8kHolJx7KGfTjQSegANUPg
+</pre>
+
+#### Using Cryptographic Keys
+In the above example, a keypair with <code>publicKey</code> identifier <code>https://example.org/publicKey.json</code> was used to sign a badge Assertion. The following resources should exist for this to be a functional example:
+
+Type       | id            | Description
+-----------|---------------|-----------
+Assertion  | <code>urn:uuid:a953081a-4bbd-4927-9653-7219bca00e3b</code> | There is no HTTP(s) <code>id</code> for this <code>Assertion</code>, because it was delivered as a JWS. It links to the BadgeClass document with the <code>badge</code> property. [See immediately above](#SignedBadge).
+BadgeClass | <code>https://example.org/robotics-badge.json</code> | A <code>BadgeClass</code> document that links to the Issuer. [See above](#BadgeClass).
+Profile    | <code>https://example.org/organization.json</code>| A issuer <code>Profile</code> document that links to the CryptographicKey document with its <code>publicKey</code> property. [See above](#Profile)
+PublicKey  | <code>https://example.org/publicKey.json</code> | A <code>CryptographicKey</code> document that links to the issuer <code>Profile</code> with its <code>owner</code> property. [See below](#CryptographicKey.
+
+
+<h3 id="CryptographicKey">CryptographicKey Example</h3>
+
+(<a data-cite="OB-20#CryptographicKey">definition</a>)
+
+A public key document should describe an Open Badges issuer's public key. For maximum compatibility, it should have its own HTTP(S) identifier, and should identify its issuer using the <code>owner</code> property. The <code>publicKeyPem</code> shown below has been abbreviated with <code>...</code> for readability.
+
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "type": "CryptographicKey",
+  "id": "https://example.org/publicKey.json",
+  "owner": "https://example.org/organization.json",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\\nMIIBG0BA...OClDQAB\\n-----END PUBLIC KEY-----\\n"
+}
+</pre>
+
+
+<h3 id="RevocationList">RevocationList Example</h3>
+
+(<a data-cite="OB-20#RevocationList">definition</a>)
+
+Issuers may have a RevocationList if they use <code>SignedBadge</code> verification. Checking this list is intended as part of the verification process for signed badges, just as checking for the hosted assertion is part of verifying a hosted badge. It is published as a JSON-LD document with type <code>RevocationList</code>. RevocationLists are linked from an issuer Profile via the <code>revocationList</code> property. The RevocationList identifies its issuer with the <code>issuer</code> property.
+
+RevocationLists may identify revoked Assertions through their <code>revokedAssertions</code> property. Individual assertions are identified either by their <code>id</code> or (legacy) <code>uid</code> properties. <code>id</code>-identified Assertions may appear in a RevocationList as that id string or as an object with an <code>id</code> property and other metadata, usually just a <code>revocationReason</code>. The below example shows <code>id</code>s in the <code>urn:uuid</code> namespace, which is a recommended namespace for signed Assertions that do not have a hosted (HTTP) <code>id</code>.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/revocationList.json",
+  "type": "RevocationList",
+  "issuer": "https://example.org/issuer",
+  "revokedAssertions": [
+    "urn:uuid:3c574c87-b96f-4f06-8eb5-68a29335b60e",
+    {
+      "id": "urn:uuid:e79a6c18-787e-4868-8e65-e6a4530fb418",
+      "revocationReason": "Honor code violation"
+    },
+    {
+      "uid": "abc123",
+      "revocationReason": "Issued in error."
+    }
+  ]
+}
+</pre>
+
+
+<h3 id="HostedBadge">Revoked Hosted Assertion Example</h3>
+
+(see more about <a data-cite="OB-20#HostedBadge">Hosted Verification</a>)
+
+Revoked hosted Assertions should be returned with the HTTP status <code>410 Gone</code>. The response body may contain an Assertion document with <code>"revoked": true</code> that contains additional metadata. It does not need to meet the full requirements of the <code>Assertion</code> class. Only <code>id</code> and <code>revoked</code> properties must be present
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "revoked": true,
+  "revocationReason": "Turns out the student's robot was just three stacked children in a trenchcoat with dryer vent hose arms."
+}
+</pre>
+
+
+<h3 id="Criteria">Criteria Example</h3>
+
+(<a data-cite="OB-20#Criteria">definition</a>)
+
+A BadgeClass's <code>criteria</code> field may be populated with a HTTP(s) URI string or an instance of the <code>Criteria</code> class. Here, a URI is used:
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "criteria": "https://example.org/robotics-badge.html"
+}
+</pre>
+
+Embedding criteria into the badge allows display platforms to render criteria information to viewers without directing them to an external website. It may be used in parallel to a criteria URI as follows:
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "criteria": {
+    "id": "https://example.org/robotics-badge.html",
+    "narrative": "To earn the **Awesome Robotics Badge**, students must construct a basic robot.\\n\\nThe robot must be able to:\\n\\n * Move forward and backwards.\\n * Pick up a bucket by its handle."
+  }
+}
+</pre>
+
+The Criteria class may also appear without using an external URI to increase portability, as fewer information dependencies then exist outside of the JSON-LD metadata. Additionally, the narrative can be used to make complex links with the BadgeClass's alignment targets.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "criteria": {
+    "id": "https://example.org/robotics-badge.html",
+    "narrative": "To earn the **Awesome Robotics Badge**, students must construct a basic robot.\\n\\nThe robot must be able  to:\\n\\n  * Move forward and backwards [1](https://example.org/robot-skills/1).\\n  * Pick up a bucket by its handle [2](https://example.org/robot-skills/2)."
+  },
+  "alignment": [
+    {
+      "targetUrl": "https://example.org/robot-skills/1",
+      "targetName": "Basic Locomotion"
+    },
+    {
+      "targetUrl": "https://example.org/robot-skills/2",
+      "targetName": "Object Manipulation"
+    }
+  ]
+}
+</pre>
+
+
+<h3 id="Evidence">Evidence Example</h3>
+
+(<a data-cite="OB-20#Evidence">definition</a>)
+
+Metadata related to evidence may be included in Assertions in several ways.
+
+The issuer may provide a text/Markdown <code>narrative</code> describing the evidence:
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "narrative": "This student invented her own type of robot. This included: \\n\\n  * Working robot arms\\n  * Working robot legs"
+}
+</pre>
+
+Evidence may be referenced by URI <code>id</code>:
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "evidence": "https://example.org/beths-robot-work.html"
+}
+</pre>
+
+Evidence may be more fully described by using the <a data-cite="OB-20#Evidence">Evidence</a> class:
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "evidence": {
+    "id": "https://example.org/beths-robot-work.html",
+    "name": "My Robot",
+    "description": "A webpage with a photo and a description of the robot the student built for this project.",
+    "narrative": "The student worked very hard to assemble and present a robot. She documented the process with photography and text.",
+    "genre": "ePortfolio"
+}
+</pre>
+
+It is possible to include multiple values for evidence in an Assertion.
+Evidence may be more fully described by using the <a data-cite="OB-20#Evidence">Evidence</a> class:
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "narrative": "This student invented her own type of robot. This included: \\n\\n  * Working robot arms\\n  * Working robot legs",
+  "evidence": [
+    {
+      "id": "https://example.org/beths-robot-photos.html",
+      "name": "Robot Photoshoot",
+      "description": "A gallery of photos of the student's robot",
+      "genre": "Photography"
+    },
+    {
+      "id": "https://example.org/beths-robot-work.html",
+      "name": "Robotics Reflection #1",
+      "description": "Reflective writing about the first week of a robotics learning journey."
+    }
+  ]
+</pre>
+
+
+<h3 id="Image">Image</h3>
+
+(<a data-cite="OB-20#Image">definition</a>)
+
+In order to provide extra useful information for rendering images, sometimes additional metadata about images is included in Badge Objects using the <code>Image</code> class.
+
+Images are often referenced by their HTTP URI where they may be accessed. Displayers usually render this as the image source in HTML.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "image": "https://example.org/beths-robot-badge.png"
+}
+</pre>
+
+However, additional properties are available, and can be referenced wherever images appear in Badge Objects. For example, a <code>caption</code> can aid in rendering alt text in browsers. If <code>author</code> is used, it may be the <code>id</code> of an Open Badges Profile, but it may be another <code>id</code> that represents the author. Displayers should not assume this is a URI that will resolve to a compatible instance of a <code>Profile</code>.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "image": {
+    "id": "https://example.org/beths-robot-badge.png",
+    "caption": "A pretty badge, with many happy trees.",
+    "author": "https://en.wikipedia.org/wiki/Bob_Ross"
+  }
+}
+</pre>
+
+
+<h3 id="SocialMediaUrls">Social Media URLs in Profiles</h3>
+
+When using the <code>url</code> property of a profile to denote a social media account, use the canonical url of the account. For example, for a Twitter account, use <code>https://twitter.com/OpenBadges</code>. For a Facebook page or account, the URL is in the format <code>https://www.facebook.com/OpenBadges</code>.
+
+
+<h3 id="badgeclass-version-control">BadgeClass Versioning</h3>
+
+The <code>version</code> property allows issuers to set a version number or string for a BadgeClass. This is particularly useful when replacing a previous version with an update.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/beths-robotics-badge-v2.json",
+  "name": "Awesomer Robotics Badge",
+  "version": 2,
+  "related": {
+    "id": "https://example.org/beths-robotics-badge.json",
+    "version": 1
+  }
+}
+</pre>
+
+
+<h2 id="Internationalization">Internationalization Examples</h2>
+
+The string internationalization features of JSON-LD make it possible for issuers to declare which language a Badge Object is expressed in:
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "@language": "en-us",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "name": "Awesome Robotics Badge"
+}
+</pre>
+
+It is also possible to list multiple versions of Badge Objects to make available multiple equivalent versions of the same entity.
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "@language": "en-us",
+  "id": "https://example.org/beths-robotics-badge.json",
+  "name": "Awesome Robotics Badge",
+  "related": [{
+      "id": "https://example.org/beths-robotics-badge-es.json?l=es",
+      "@language": "es"
+    }]
+}
+</pre>
+
+**Notes**:
+
+* Language codes must be compatible with [[[BCP47]]]. Think "en" or "es-MX".
+* JSON-LD allows much more expressive combinations of multiple languages in one document. It is likely that you may be able to produce Badge Objects taking advantage of these features that will not be understood by some or all validators or display tools. It is recommended to keep implementations as simple as possible and communicate with the standards group when you want to move beyond the example techniques expressed here.
+
+
+<h2 id="Endorsement">Endorsement Examples</h2>
+
+An endorser can use an <code>Endorsement</code> to indicate trust in an email address. Suppose the [issuer Profile record above](#Profile) exists, but inspectors are unsure whether it is a trustworthy record that truly represents the organization it describes. Endorsements can show that an external party has verified one or more properties of the Issuer. Automated services could be developed to verify properties like <code>email</code> or <code>telephone</code>, and human verification services could provide more in-depth verification.
+
+Here, an endorser claims to have verified the email address published in the Profile.
+<pre>
+{
+ "@context": "https://w3id.org/openbadges/v2",
+ "type": "Endorsement",
+ "id": "https://example.org/endorsement-123.json",
+ "issuer": "https://example.org/issuer-5.json",
+ "claim": {
+   "id": "https://example.org/organization.json",
+   "email": "contact@example.org",
+ },
+ "verification": {
+   "type": "hosted"
+ }
+}
+</pre>
+
+Another prominent use of Endorsements is to provide a comment expressing approval of a BadgeClass, that it is a good representation of the achievement it describes. The endorser could publish the following about the [above](#BadgeClass) BadgeClass.
+<pre>
+{
+ "@context": "https://w3id.org/openbadges/v2",
+ "type": "Endorsement",
+ "id": "https://example.org/endorsement-124.json",
+ "issuer": "https://example.org/issuer-5.json",
+ "claim": {
+   "id": "https://example.org/robotics-badge.json",
+   "endorsementComment": "This badge and its associated learning material are great examples of beginning robotics education."
+ },
+ "verification": {
+   "type": "hosted"
+ }
+}
+</pre>
+
+The same method could be used to support a single recipient's achievement through endorsing an <code>Assertion</code>. Here the endorser also offers an addition to the evidence to be considered associated with the badge.
+<pre>
+{
+ "@context": "https://w3id.org/openbadges/v2",
+ "type": "Endorsement",
+ "id": "https://example.org/endorsement-125.json",
+ "issuer": "https://example.org/issuer-5.json",
+ "claim": {
+   "id": "https://example.org/beths-robotics-badge.json",
+   "endorsementComment": "This student built a great robot.",
+   "evidence": "https://example.org/photos/my-photos-of-the-robot-competition.html"
+ },
+ "verification": {
+   "type": "hosted"
+ }
+}
+</pre>
+
+<div></div>
+`;

--- a/ob_v2p0/impl/ob-impl-v2p0.html
+++ b/ob_v2p0/impl/ob-impl-v2p0.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <script src='https://purl.imsglobal.org/spec/respec-ims-default.js' async class='remove'></script>
+    <script src='../shared/localBiblio.js' class="remove"></script>
+    <script src='../shared/contributors.js' class="remove"></script>
+    <script src='../shared/iprs.js' class="remove"></script>
+    <script class='remove'>
+        var respecConfig = {
+            mainSpecTitle: "Open Badges Specification",
+            mainSpecBiblioKey: "OB-20",
+            specTitle: "Open Badges Implementation Guide",
+            shortName: "ob/impl",
+            specStatus: "IMS Final Release",
+            specDate: "October 18, 2018",
+            specVersion: "2.0",
+            specNature: "informative",
+            specType: "spec",
+            format: "markdown",
+            maxTocLevel: "3",
+            skipCertGuideConformanceRef: false,
+            contributors: _contributors,
+            iprs: _iprs,
+
+            /*
+            * Define a temporary localBiblio to resolve references to spec documents that don't exist
+            * on the IMS purl server. Once the documents exist, remove this localBiblio.
+            */
+            localBiblio: _localBiblio
+        };
+    </script>
+</head>
+
+<body>
+    <section class="introductory" id="abstract">
+        <script class="transclude" src="../shared/ob-abstract.md" data-id="abstract"></script>
+        <p>
+            This document aims to provide recommended practices, gathered from real-world implementations and
+            experience, that an implementation of the specification should consider following.
+        </p>
+
+    </section>
+
+    <section>
+        <h2>Introduction</h2>
+
+        <section id="conformance">
+            <h3>Conformance and Certification</h3>
+        </section>
+
+        <section id="document-set">
+            <script class="transclude" src="../shared/ob-documents.md" data-id="documents"></script>
+        </section>
+
+        <section id="terminology">
+                <script class="transclude" src="../shared/ob-terms.md" data-id="terms"></script>
+        </section>    
+    </section>
+
+    <script class="transclude" src="ob-impl-v2p0.md" data-id="md"></script>
+
+    <section class="appendix informative" id="revisionhistory">
+        <h1>Revision History</h1>
+        <section>
+            <h3>Version History</h3>
+            <table title="Revision History">
+                <thead>
+                    <tr>
+                        <th>Version No.</th>
+                        <th>Release Date</th>
+                        <th>Comments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Version 2.0 IMS Final Release</td>
+                        <td>October 18, 2018</td>
+                        <td>
+                            <ul>
+                                <li>Recommendations for urn-based identifiers</li>
+                                <li>Recommendations for deletion of BadgeClass</li>
+                            </ul>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Version 2.0 IMS Final Release</td>
+                        <td>April 12, 2018</td>
+                        <td>Original release.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+
+</html>

--- a/ob_v2p0/impl/ob-impl-v2p0.md
+++ b/ob_v2p0/impl/ob-impl-v2p0.md
@@ -1,0 +1,131 @@
+var md = `
+
+## <a id="context"></a> Context
+### Overview
+Open Badges put learners in control of how and where they share verifiable evidence of their skills and achievements with people, organizations, and social platforms.
+
+Open Badges enable learner-control of sharing their credentials and communicating their meaning to educational institutions and employers. These credentials show evidence of rigor of the academic achievement through the inclusion of criteria, assessment details, learner's evidence, alignment with external frameworks, accreditation details, and endorsements.
+
+OBv2 introduces features that significantly improve the verifiability, portability, reliability, and discoverability of Open Badges.
+
+<img alt="Open Badges workflow illustration" src="assets/image1.png" style="width: 75%; height:75%"/>
+
+## Use Cases
+The following use cases are supported:
+
+1. Creating a BadgeClass - BadgeClass objects can be created to build a catalog of badges that may be available to earn from the issuer. They may include information about the achievement including how to earn it or learn more about the issuer and achievement itself.
+2. Issuing badge Assertions to recipients - With a catalog of badges (BadgeClasses) prepared, you can issue those badges to recipients by creating Assertion objects. The Assertion is the representation of an awarded badge and may include evidence and supporting information on how the recipient became eligible for it.
+3. Displaying Open Badges - Typically, when an Open Badge is displayed, the Assertion and related objects are displayed on a screen in human-readable format. Supporting this enables the recipient to showcase their earned achievements and choose to allow others to view those.
+4. Importing Open Badges - Badge Hosts must support the function of importing Open Badges. This involves a process by which an Assertion and related objects are validated for format and integrity. Import of Open Badge data normally results in the subsequent display of that data.
+
+## Recommended Practices
+These recommended practices are in addition to the information provided in the specification document and certification requirements document. Please refer to each of these resources for comprehensive implementation details.
+
+### Accessibility
+- Ensure that the user interfaces of your platform are accessible to people with disabilities by following guidelines provided in [[[WCAG20]]].
+
+### Badge Issuer
+#### Issuing Badges
+Creating Badge Classes
+- Accessibility: Encouraging alt text for images - The Image data object contains a “Caption” property which can be rendered as alt text for images. Badge platforms should consider adding features that prompt users who create badge classes to submit Caption text to be used for this purpose. 
+- Use of urn-based identifiers for embedded BadgeClasses presents a possibility that multiple data versions would be published under the same urn embedded in different Assertions. HTTP identifiers for BadgeClasses allows relying parties the best possible means to resolve possible differences to know which version best represents the current wishes of the issuer.
+
+Delivering badges to recipients
+- Typically, an Open Badge is made available to recipients through an email message or other notification that contains instructions and a mechanism for downloading the badge without signing up for any account. 
+
+Recipient should be notified
+- Any badge recipient should be notified when a badge is issued to them. Notification should contain details and/or a link to critical information about the badge. Allow for unsubscription of future notifications. Abuse prevention is key here. Allow recipients to opt out of email from your service permanently.
+
+Claiming badges by recipient
+- Badge earners should have agency in whether they accept the badge issued to them. Give earners the opportunity to choose to receive (“claim”) the badge if they desire. You may designate an issued badge as “not yet claimed” within your service. 
+- Give recipients the choice to accept or reject the badge and options to express their acknowledgement or rejection. Rejection may mean deleting the badge and all associated data with it.
+- Consider implementing a reminder process if a recipient has not claimed their badge. This applies to systems that have account management as a function. Important to respect opt-out choices here.
+- Consider obtaining acceptance from the recipient before publishing a signed assertion which, unlike hosted assertions, cannot be unpublished. 
+- Implement a process that enables the reporting of abusive content.
+- Recipient identifier (email address or phone number) should be confirmed prior to the recipient doing other things with the badge like making it private or public.
+
+Revoking badge assertions
+- The revocation properties of Open Badges provide a mechanism by which a badge issuer may retract or nullify existing badge assertions. Revocation is an intentional act of a badge issuer and differs from the expiration date of a badge assertion, though both expiration and revocation are ways to communicate that the badge assertion is no longer current. 
+
+Maintaining hosted resources for badge verification
+- A critical feature of Open Badges is the ability for consumers to verify the badge. Maintain necessary hosted verification resources for the entire useful life of issued badges. This requires services to maintain a high level of availability. 
+- Consider processes to prevent authorized BadgeClass owners from deleting existing BadgeClasses from which assertions have been issued. BadgeClasses are required resources for validating and verifying assertions. If the issuer does desire to invalidate all awarded assertions of the BadgeClass to be deleted, it is recommended to treat these assertions as revoked and supply a relevant revocationReason through the RevocationList or hosted Assertion verification URLs.
+
+#### Publishing Badges
+Expectations of publishing badges
+  - The act of publishing a badge assertion means that the badge becomes a publicly accessible URL. 
+
+Accessibility: Encouraging alt text for images
+  - The Image data object contains a “Caption” property which can be rendered as alt text for images. If a badge contains Caption data, consider using it to populate an image’s alt text field. 
+
+#### Ending Badge Services
+When a badge service provider must close down its operations, there are a number of actions that are recommended to ensure continuity of service for the badge recipients. In order for previously-issued badges to remain valid, steps should be taken to ensure that those hosted resources that are necessary for the validation of the badges remain intact. If a badging service must be shut down, here are a number of actions to consider taking:
+  - Move hosted assertions over to a new location and implement redirects.
+  - Convert to signed assertions and redeliver to all recipients. (This will result in all previously hosted badges becoming invalid.)
+  - Consider reissuing assertions using a different service or verification method that has less onerous persistent hosting requirements.
+
+### Badge Displayer
+General
+  - Where possible, include contextual information on how to learn more about the Issuer, the Badge and possibly how to earn it.
+
+Displaying Images
+  - The Caption property of the Image class should be exposed as a caption or alt text on the page.
+  - Image should be fully visible, not truncated or distorted. If provided,include caption as caption or alt text.
+
+Displaying Recipient Name
+  - If available and allowed by the badge recipient, the name of the recipient should be displayed. However, privacy considerations must be paramount. Publicly available badge assertions must only display recipients’ names following explicit permission of the recipient. Recipients must be able to change this setting at any time.
+  - Recipient name is not part of the Assertion data itself, and the system should not trust name data unless it is also the issuing platform and that data was entered and verified by a trusted source like the issuer itself (alongside data that is served in the Assertion). If name is presented, the system should make clear to the viewer why it trusts this name to be associated with a specific Assertion.
+
+Displaying Evidence
+  - Provide convenient access to evidence. When possible, display multimedia evidence alongside the earned badge.
+
+Displaying JSON
+  - Provide access to the original JSON or full data of the badge.
+
+Supporting Verification
+  - Display the date of last verification.
+  - Update system's verification record when viewers request reverification.
+  - If the badge is not valid display human-readable error messages as best possible.
+  - If the badge data is not available, consider use of “Could not verify” message to account for cases of temporary unavailability (like server outages). 
+  - Provide options for retrying verification in the event a resource was missing or otherwise unavailable.
+  - Nuanced user-friendly messages in UI are recommended for various types of http responses; e.g. 503 vs 404 vs 410 gone with revocation.
+
+Updating Assertions - On occasion, an already-issued assertion must be updated (e.g. newly available evidence in a hosted assertion). Consider the following:
+  - Updates should be reflected within the user-facing interface.
+  - Display the last time the assertion and associated objects were fetched and/or updated.
+
+### Badge Host
+#### Hosting Badges
+- Certification - Those interested in receiving IMS certification as Host should also strongly consider becoming certified as Displayer.
+- Collections - Hosts should allow badge recipients to group badges into collections or pages to present the badges together.
+- Extensions - Implement specific display functionality tailored to well-used extensions. 
+- JSON availability - Make JSON available to consumers who wish to view it.
+
+#### Importing Badges
+- Allow importing of signed assertion strings.
+- Helpful errors should be presented to the user in the event the import failed.
+
+#### Sharing Badges
+- Provide instructions on how to share your badge.
+- Allow sharing to be retracted by the badge recipient.
+- Recommended types of sharing options:
+    <ul>
+        <li>Download baked badge image file</li>
+        <li>Social media integrations</li>
+        <li>Copy URL to JSON assertion</li>
+        <li>Retrieve HTML to display the badge</li>
+    </ul>
+
+### Other
+
+#### Extensions
+Creators of extensions are encouraged to submit extensions to the [public repository](https://github.com/IMSGlobal/openbadges-specification/tree/master/extensions) for review and feedback by the IMS workgroup. (Can also include a link to info on OB extensions and samples.)
+
+#### Emerging Concepts and Concerns
+Versioning
+  - Badge Issuer: When a BadgeClass or Assertion is updated, use the version property to number your versions and provide references between them.
+  - Badge Host: Implement "version" detection for imported badges and relate between them. 
+  - Technical notes: There is much to be discovered about what a successful interaction between Issuer and Host for versioning BadgeClasses or Assertions looks like.
+
+<div></div>
+`;

--- a/ob_v2p0/ob-errata-v2p0.html
+++ b/ob_v2p0/ob-errata-v2p0.html
@@ -14,7 +14,7 @@
             specTitle: "Open Badges Specification Errata",
             shortName: "ob",
             specStatus: "IMS Final Release",
-            specDate: "April 12, 2019",
+            specDate: "April 12, 2018",
             specVersion: "2.0",
             specNature: "normative",
             specType: "errata",
@@ -50,25 +50,22 @@
 
     <section class="appendix informative" id="revisionhistory">
         <h1>Revision History</h1>
-        <section>
-            <h3>Version History</h3>
-            <table title="Revision History">
-                <thead>
-                    <tr>
-                        <th>Version No.</th>
-                        <th>Release Date</th>
-                        <th>Comments</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Version 2.0 IMS Final Release</td>
-                        <td>April 12, 2018</td>
-                        <td>First release.</td>
-                    </tr>
-                </tbody>
-            </table>
-        </section>
+        <table title="Revision History">
+            <thead>
+                <tr>
+                    <th>Version No.</th>
+                    <th>Release Date</th>
+                    <th>Comments</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Version 2.0 IMS Final Release</td>
+                    <td>April 12, 2018</td>
+                    <td>First release.</td>
+                </tr>
+            </tbody>
+        </table>
     </section>
 </body>
 

--- a/ob_v2p0/ob-errata-v2p0.html
+++ b/ob_v2p0/ob-errata-v2p0.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <script src='https://purl.imsglobal.org/spec/respec-ims-default.js' async class='remove'></script>
+    <script src='shared/localBiblio.js' class="remove"></script>
+    <script src='shared/contributors.js' class="remove"></script>
+    <script src='shared/iprs.js' class="remove"></script>
+    <script class='remove'>
+        var respecConfig = {
+            mainSpecTitle: "Open Badges Specification",
+            mainSpecBiblioKey: "OB-20",
+            specTitle: "Open Badges Specification Errata",
+            shortName: "ob",
+            specStatus: "IMS Final Release",
+            specDate: "April 12, 2019",
+            specVersion: "2.0",
+            specNature: "normative",
+            specType: "errata",
+            format: "markdown",
+            maxTocLevel: "2",
+            skipCertGuideConformanceRef: false,
+            contributors: _contributors,
+            iprs: _iprs,
+
+            /*
+            * Define a temporary localBiblio to resolve references to spec documents that don't exist
+            * on the IMS purl server. Once the documents exist, remove this localBiblio.
+            */
+            localBiblio: _localBiblio
+        };
+    </script>
+</head>
+
+<body>
+    <section class="introductory" id="abstract">
+        <script class="transclude" src="shared/ob-abstract.md" data-id="abstract"></script>
+    </section>
+
+    <section>
+        <h2>Introduction</h2>
+
+        <section id="document-set">
+            <script class="transclude" src="shared/ob-documents.md" data-id="documents"></script>
+        </section>
+    </section>
+
+    <script class="transclude" src="ob-errata-v2p0.md" data-id="md"></script>
+
+    <section class="appendix informative" id="revisionhistory">
+        <h1>Revision History</h1>
+        <section>
+            <h3>Version History</h3>
+            <table title="Revision History">
+                <thead>
+                    <tr>
+                        <th>Version No.</th>
+                        <th>Release Date</th>
+                        <th>Comments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Version 2.0 IMS Final Release</td>
+                        <td>April 12, 2018</td>
+                        <td>First release.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+
+</html>

--- a/ob_v2p0/ob-errata-v2p0.md
+++ b/ob_v2p0/ob-errata-v2p0.md
@@ -1,0 +1,7 @@
+var md = `
+
+## Errata
+
+There is no errata.
+
+`;

--- a/ob_v2p0/ob-spec-v2p0.html
+++ b/ob_v2p0/ob-spec-v2p0.html
@@ -81,7 +81,7 @@
         </section>
         <section>
             <h3>Version History</h3>
-            <table title="Revision History">
+            <table title="Version History">
                 <thead>
                     <tr>
                         <th>Version No.</th>

--- a/ob_v2p0/ob-spec-v2p0.html
+++ b/ob_v2p0/ob-spec-v2p0.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <script src='https://purl.imsglobal.org/spec/respec-ims-default.js' async class='remove'></script>
+    <script src='shared/localBiblio.js' class="remove"></script>
+    <script src='shared/contributors.js' class="remove"></script>
+    <script src='shared/iprs.js' class="remove"></script>
+    <script class='remove'>
+        var respecConfig = {
+            mainSpecTitle: "Open Badges Specification",
+            mainSpecBiblioKey: "OB-20",
+            specTitle: "Open Badges Specification",
+            shortName: "ob",
+            specStatus: "IMS Final Release",
+            specDate: "April 12, 2018",
+            specVersion: "2.0",
+            specNature: "normative",
+            specType: "spec",
+            format: "markdown",
+            maxTocLevel: "2",
+            skipCertGuideConformanceRef: false,
+            contributors: _contributors,
+            iprs: _iprs,
+
+            /*
+            * Define a temporary localBiblio to resolve references to spec documents that don't exist
+            * on the IMS purl server. Once the documents exist, remove this localBiblio.
+            */
+            localBiblio: _localBiblio
+        };
+    </script>
+</head>
+
+<body>
+    <section class="introductory" id="abstract">
+        <script class="transclude" src="shared/ob-abstract.md" data-id="abstract"></script>
+    </section>
+
+    <section>
+        <h2>Introduction</h2>
+
+        <section id="conformance">
+            <h3>Conformance and Certification</h3>
+        </section>
+
+        <section id="document-set">
+            <script class="transclude" src="shared/ob-documents.md" data-id="documents"></script>
+        </section>
+
+        <section id="terminology">
+            <script class="transclude" src="shared/ob-terms.md" data-id="terms"></script>
+        </section>
+    </section>
+
+    <script class="transclude" src="ob-spec-v2p0.md" data-id="md"></script>
+
+    <section class="appendix informative" id="revisionhistory">
+        <h1>Revision History</h1>
+        <section>
+            <h3>Changes</h3>
+            <ul>
+                <li>
+                    <a href="https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/history/2.0.html">
+                        From 1.1 to 2.0</a>
+                </li>
+                <li>
+                    <a href="https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/history/1.1.html">
+                        From 1.0 to 1.1</a>
+                </li>
+                <li>
+                    <a href="https://github.com/mozilla/openbadges/wiki/Assertion-Specification-Changes">
+                        From 0.5 to 1.0</a>
+                </li>
+                <li>
+                    <a href="https://github.com/mozilla/openbadges-backpack/wiki/Assertions/_history">
+                        Early history of the specification</a>
+                </li>
+            </ul>
+        </section>
+        <section>
+            <h3>Version History</h3>
+            <table title="Revision History">
+                <thead>
+                    <tr>
+                        <th>Version No.</th>
+                        <th>Release Date</th>
+                        <th>Comments</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Version 2.0 IMS Final</td>
+                        <td>April 12, 2018</td>
+                        <td>Covers Issuer, Displayer, and Host conformance and certification.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+
+</html>

--- a/ob_v2p0/ob-spec-v2p0.md
+++ b/ob_v2p0/ob-spec-v2p0.md
@@ -1,0 +1,536 @@
+var md = `
+
+## Concepts
+This specification describes a method for packaging information about accomplishments, embedding it into portable image files as digital badges, and establishing resources for its validation. It includes term definitions for representations of data in Open Badges. These term definitions appear in the current [[[OB-JSONLD-20]]] for the Open Badges Specification.
+
+In other words, Open Badges contain detailed metadata about achievements. Who earned a badge, who issued it, and what does it mean? The data is all inside. A simple example:
+
+<pre>
+{
+  "@context": "https://w3id.org/openbadges/v2",
+  "id": "https://example.org/assertions/123",
+  "type": "Assertion",
+  "recipient": {
+    "type": "email",
+    "identity": "alice@example.org"
+  },
+  "issuedOn": "2016-12-31T23:59:59+00:00",
+  "verification": {
+    "type": "hosted"
+  },
+  "badge": {
+    "type": "BadgeClass",
+    "id": "https://example.org/badges/5",
+    "name": "3-D Printmaster",
+    "description": "This badge is awarded for passing the 3-D printing knowledge and safety test.",
+    "image": "https://example.org/badges/5/image",
+    "criteria": {
+      "narrative": "Students are tested on knowledge and safety, both through a paper test and a supervised performance evaluation on live equipment"
+    },
+    "issuer": {
+      "id": "https://example.org/issuer",
+      "type": "Profile",
+      "name": "Example Maker Society",
+      "url": "https://example.org",
+      "email": "contact@example.org",
+      "verification": {
+         "allowedOrigins": "example.org"
+      }
+    }
+  }
+}
+</pre>
+
+### Open Badges in Linked Data
+[Linked Data](https://en.wikipedia.org/wiki/Linked_data) is a method of publishing data so that it can be understood in a variety of contexts. Open Badges are expressed in [JSON-LD](http://json-ld.org/) so that they can include and be included in documents outside the purposes considered in this specification. Open Badges take advantage of JSON-LD's features for internationalization/localization, identifying objects by unique IRIs, and extensibility.
+
+Open Badges are expressed as linked data so that badge resources can be connected. The issuer's Profile in the above example is identified by the "id" <code>https://example.org/issuer</code>, which is a URL at which the profile can be discovered. Badge Objects, the instances of the data classes in the Open Badges Vocabulary, can link to one another's hosted URLs or can embed representations of their connected resources for increased portability. See <a data-cite="OB-EXAMPLES#open-badges-in-linked-data-0">Linked Data</a> examples.
+
+### Internationalization and Multilingual Badges
+Open Badges are used by thousands of issuers around the world, and users of those badges speak many languages. Because Open Badges is a Linked Data vocabulary expressed in JSON-LD, there are some excellent features available to issuers and platforms to use Open Badges in their preferred language. See [String internationalization in JSON-LD](http://json-ld.org/spec/latest/json-ld/#string-internationalization). Issuers can: 
+
+* Declare which language a Badge Object is expressed in using language tags compliant with [[BCP47]].
+* List multiple versions of Badge Objects to make available multiple equivalent versions of the same entity.
+
+Additionally, developers who wish to write code in a language other than English can build a JSON-LD context file in their preferred language and then encounter badge property names familiar to them and their teams.
+
+See <a data-cite="OB-EXAMPLES#Internationalization">Internationalization Examples</a>.
+
+## Open Badges Vocabulary
+The Open Badges Vocabulary defines several data classes used to express achievements that is understandable in software and services that implement Open Badges. There are three core data classes: **[Assertions](#Assertion)**, **[BadgeClasses](#BadgeClass)**, and **[Profiles](#Profile)**. A set of one expression of each of these may be constructed into a valid Open Badge. Each data class is a collection of properties and values, and each defines which are mandatory and optional as well as the restrictions on the values those properties may take. They are published as [[JSON-LD]] for interoperability. If properties are included in JSON that cannot be mapped to JSON-LD terms defined in the object's <code>@context</code>, they are not considered part of the badge object's meaning.
+
+**Extensions**:
+ 
+Each Badge Object may have [additional properties](#additional-properties) beyond those defined here. Some of these additional properties may take the form of an Open Badges Extension, a structure that follows a standard format for collaboratively extending Badge Objects so that any issuer, earner, or consumer can understand the information added to badges. ([More...](#Extensions))
+
+<h3 id="Assertion">Assertion</h3> (<a data-cite="OB-EXAMPLES#Assertion">example</a>)
+Assertions are representations of an awarded badge, used to share information about a badge belonging to one earner. Assertions are packaged for transmission as JSON objects with a set of mandatory and optional properties. Fields marked **in bold letters** are mandatory.
+
+| Property | Expected Type | Description
+| -------- | ------------- | -----------
+| **id** | IRI | Unique IRI for the Assertion. If using hosted verification, this should be the URI where the assertion is accessible. For signed Assertions, it is recommended to use a UUID in the <code>urn:uuid</code> namespace.
+| **type** | JSON-LD type ([Multiple values allowed](#array))| valid JSON-LD representation of the Assertion type. In most cases, this will simply be the string <code>Assertion</code>. An array including <code>Assertion</code> and other string elements that are either URLs or compact IRIs within the current context are allowed.
+| <a id="recipient"></a>**recipient** | [IdentityObject](#IdentityObject) | The recipient of the achievement.
+| **badge** | @id: [BadgeClass](#BadgeClass) | IRI or document that describes the type of badge being awarded. If an HTTP/HTTPS IRI The endpoint should be a [BadgeClass](#BadgeClass).
+| <a id="verify"></a> **verification** | [VerificationObject](#VerificationObject) | Instructions for third parties to verify this assertion. (Alias "verify" may be used in [context](v2/context.json).)
+| <a id="issueDate"></a>**issuedOn** | [DateTime](#dateTime) | Timestamp of when the achievement was awarded.
+| image | @id: [Image](#Image) | IRI or document representing an image representing this user's achievement. This must be a PNG or SVG image, and should be prepared via the [Baking specification](./baking/index.html). An 'unbaked' image for the badge is defined in the [BadgeClass](#BadgeClass) and should not be duplicated here.
+| <a id="evidence"></a>evidence | @id: [Evidence](#Evidence) ([Multiple values allowed](#array)) | IRI or document describing the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible. 
+| <a id="narrative"></a>narrative | Text or [Markdown Text](#MarkdownText) | A narrative that connects multiple pieces of evidence. Likely only present at this location if <code>evidence</code> is a multi-value array. 
+| <a id="expirationDate"></a>expires | [DateTime](#dateTime) | If the achievement has some notion of expiry, this indicates a timestamp when a badge should no longer be considered valid. After this time, the badge should be considered expired.
+| revoked  | Boolean       | Defaults to <code>false</code> if Assertion is not referenced from a [<code>revokedAssertions</code>](#revokedAssertions) list and may be omitted. See [RevocationList](#RevocationList). If <code>revoked</code> is true, only <code>revoked</code> and <code>id</code> are required properties, and many issuers strip a hosted Assertion down to only those properties when revoked.
+| revocationReason | Text  | Optional published reason for revocation, if revoked. 
+
+**Deprecated properties still in use by some implementations**: 
+
+* <a id="uid"></a>uid -- String -- Unique Identifier for the badge. This is expected to be *locally* unique on a per-issuer basis and for hosted badges on a per-origin basis. It may not be necessarily globally unique. <code>uid</code> has been replaced by the IRI-based <code>id</code> property. It should not be used in v2.0+ Assertions.
+
+
+<h3 id="BadgeClass">BadgeClass</h3> (<a data-cite="OB-EXAMPLES#BadgeClass">example</a>)
+A collection of information about the accomplishment recognized by the Open Badge. Many assertions may be created corresponding to one BadgeClass
+
+Property | Expected Type | Description
+---------|---------------|-----------
+**id** | IRI | Unique IRI for the BadgeClass. Most platforms to date can only handle HTTP-based IRIs. Issuers using signed assertions are encouraged to publish BadgeClasses using HTTP IRIs but may instead use ephemeral BadgeClasses that use an <code>id</code> in another scheme such as <code>urn:uuid</code>.
+**type** | JSON-LD type ([Multiple values allowed](#array))| valid JSON-LD representation of the BadgeClass type. In most cases, this will simply be the string <code>BadgeClass</code>. An array including <code>BadgeClass</code> and other string elements that are either URLs or compact IRIs within the current context are allowed.
+**name** | Text | The name of the achievement.
+**description** | Text | A short description of the achievement.
+**image** | @id: [Image](#Image) | IRI of an image representing the achievement. May be a [Data URI](http://en.wikipedia.org/wiki/Data_URI_scheme), or URI where the image may be found.
+<a id="criteria"></a>**criteria** | @id: [Criteria](#Criteria) | URI or embedded criteria document describing how to earn the achievement.
+**issuer** | @id: [Profile](#Profile) | IRI or document describing the individual, entity, or organization that issued the badge.
+alignment | [AlignmentObject](#Alignment) ([Multiple values allowed](#array))| An object describing which objectives or educational standards this badge aligns to, if any.
+<a id="tags"></a>tags | Text ([Multiple values allowed](#array)) | A tag that describes the type of achievement.
+
+
+<h3 id="Profile">Profile (Issuer)</h3>
+
+(<a data-cite="OB-EXAMPLES#Profile">example</a>)
+
+A Profile is a collection of information that describes the entity or organization using Open Badges. Issuers must be represented as Profiles, and recipients, endorsers, or other entities may also be represented using this vocabulary. Each Profile that represents an Issuer may be referenced in many BadgeClasses that it has defined. Anyone can create and host an Issuer file to start issuing Open Badges. Issuers may also serve as recipients of Open Badges, often identified within an Assertion by specific properties, like their url or contact email address. An Issuer Profile is a subclass of the general Profile with some additional requirements.
+
+Property | Expected Type | Description
+---------|---------------|------------
+**id** | IRI | Unique IRI for the Issuer/Profile file. Most platforms to date can only handle HTTP-based IRIs.
+**type** | JSON-LD type ([Multiple values allowed](#array))| Valid JSON-LD representation of the Issuer or Profile type. In most cases, this will simply be the string <code>Issuer</code> or the more general <code>Profile</code>. An array including <code>Issuer</code> and other string elements that are either URLs or compact IRIs within the current context are allowed.
+name | Text | The name of the entity or organization.
+url | IRI | The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP. (<a data-cite="OB-EXAMPLES#SocialMediaUrls">examples</a>).
+telephone | Text | A phone number for the entity. For maximum compatibility, the value should be expressed as a <code>+</code> and country code followed by the number with no spaces or other punctuation, like <code>+16175551212</code> ([E.164 format](http://en.wikipedia.org/wiki/E.164)).
+description | Text | A short description of the issuer entity or organization.
+image | @id: [Image](#Image) | An image representing the issuer. May be a Data URI, or URI where the image may be found or an instance of the Image class.
+email | Text | Contact address for the individual or organization.
+publicKey | @id: [CryptographicKey](#CryptographicKey) | The key(s) an issuer uses to sign Assertions.
+verification | [VerificationObject](#VerificationObject) | Instructions for how to verify Assertions published by this Profile.
+revocationList | IRI: [RevocationList](#RevocationList) | HTTP URI of the Badge Revocation List used for marking revocation of signed badges.
+
+**A note on required properties**:
+When used to represent a recipient of badges, only <code>id</code> and <code>type</code> are required to enable pseudonymous usage. When used as a badge issuer, the following properties are required: <code>id</code>, <code>type</code>, <code>name</code>, <code>url</code>, and <code>email</code>.
+
+
+<h3 id="IdentityObject">IdentityObject</h3>
+A collection of information about the recipient of a badge.
+
+Property | Expected Type | Description
+--------|------------|-----------
+**identity** | [identityHash](#identityHash) or Text | Either the hash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information where there is an expectation of privacy, it is strongly recommended that an IdentityHash be used.
+**type** | property IRI | The property by which the recipient of a badge is identified. This value should be an IRI mapped in the present context. For example, <code>email</code> maps to <code>http://schema.org/email</code> and indicates that the <code>identity</code> of the <code>IdentityObject</code> will represent a value of a [Profile's](#Profile) <code>email</code> property. Currently the only supported value for many platforms that implement Open Badges is <code>email</code>, but other properties are available. See [Profile Identifier Properties](#ProfileIdentifierProperties). 
+**hashed** | Boolean | Whether or not the <code>identity</code> value is hashed.
+salt | Text | If the recipient is hashed, this should contain the string used to salt the hash. If this value is not provided, it should be assumed that the hash was not salted.
+
+
+<h3 id="VerificationObject">VerificationObject</h3>
+A collection of information allowing an inspector to verify an Assertion. This is used as part of verification instructions in each Assertion but also as an instruction set in an issuer's Profile to describe verification instructions for Assertions the issuer awards.
+
+Property | Expected Type | Description
+---------|---------------|-----------
+**type** | JSON-LD type  ([Multiple values allowed](#array))| The type of verification method. Supported values for single assertion verification are <code>HostedBadge</code> and <code>SignedBadge</code> (aliases in <a data-cite="OB-JSONLD-20#">context</a>) are available: <code>hosted</code> and <code>signed</code>). For instances used in Profiles, the type <code>VerificationObject</code> should be used.
+verificationProperty | @id | The @id of the property to be used for verification that an Assertion is within the allowed scope. Only <code>id</code> is supported. Verifiers will consider <code>id</code> the default value if <code>verificationProperty</code> is omitted or if an issuer Profile has no explicit verification instructions, so it may be safely omitted.
+startsWith | URI fragment string | The URI fragment that the verification property must start with. Valid Assertions must have an <code>id</code> within this scope. Multiple values allowed, and Assertions will be considered valid if their <code>id</code> starts with one of these values.
+<a id="allowedOrigins"></a>allowedOrigins | URI hostname string ([Multiple values allowed](#array)) | The <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">host registered name subcomponent</a> of an allowed origin. Any given <code>id</code> URI will be considered valid.
+
+<code>HostedVerification</code> and <code>SignedVerification</code> are subclasses of <code>VerificationObject</code>. Future subclasses may be developed to indicate instructions for verifying Assertions using different methods, such as blockchain-based procedures.
+
+#### HostedBadge
+Hosted badge Assertions that have an HTTP(s) <code>id</code> simply need to declare a verification type of <code>HostedBadge</code>, and verification will use the Assertion's <code>id</code> property.
+
+#### SignedBadge
+Cryptographically signed Assertions need to declare a verification type of <code>SignedBadge</code> within the JSON-LD. These badges are typically delivered as JSON Web Signatures (JWSs), so the signature value is outside the Assertion content, wrapping it. However, it may help to identify which publicKey is associated with the signature within the badge, so the <code>creator</code> field is available to be used in SignedBadges.
+
+Property | Expected Type | Description
+---------|---------------|-----------
+**type** | JSON-LD type ([Multiple values allowed](#array)) | The type of verification method: <code>SignedBadge</code> (or legacy alias <code>signed</code>).
+creator  | @id: [CryptographicKey](#CryptographicKey) | The (HTTP) id of the key used to sign the Assertion. If not present, verifiers will check public key(s) declared in the referenced issuer Profile. If a key is declared here, it must be authorized in the issuer Profile as well. <code>creator</code> is expected to be the dereferencable URI of a document that describes a [CryptographicKey](#CryptographicKey).
+
+
+<h3 id="Evidence">Evidence</h3>
+
+(<a data-cite="OB-EXAMPLES#Evidence">example</a>)
+
+Descriptive metadata about evidence related to the issuance of an Assertion. Each instance of the Evidence class present in an Assertion corresponds to one entity, though a single entry can describe a set of items collectively. There may be multiple <code>evidence</code> entries referenced from an Assertion. The <code>narrative</code> property is also in scope of the Assertion class to provide an overall description of the achievement related to the badge in rich text. It is used here to provide a narrative of achievement of the specific entity described.
+
+If both the <code>description</code> and <code>narrative</code> properties are present, displayers can assume the <code>narrative</code> value goes into more detail and is not simply a recapitulation of <code>description</code>.
+
+Property | Expected Type | Description
+---------|---------------|-----------
+type     | JSON-LD Type ([Multiple values allowed](#array)) | Defaults to [Evidence](#Evidence).
+id       | IRI           | The URI of a webpage presenting evidence of achievement. 
+narrative | Text or Markdown Text | A narrative that describes the evidence and process of achievement that led to an Assertion.
+name     | Text          | A descriptive title of the evidence.
+description | Text       | A longer description of the evidence.
+genre    | Text          | A string that describes the type of evidence. For example, <code>Poetry</code>, <code>Prose</code>, <code>Film</code>.
+audience | Text          | A description of the intended audience for a piece of evidence.
+
+For evidence that is ephemeral or completely described within an Assertion via use of the Evidence class, if it is necessary to identify this evidence piece uniquely in an overall narrative, an <code>id</code> of type <code>urn:uuid</code> or otherwise outside the HTTP scheme may be used, but displayers may have less success displaying this usage meaningfully. 
+
+
+<h3 id="Image">Image</h3> 
+
+(<a data-cite="OB-EXAMPLES#Image">example</a>)
+
+Metadata about images that represent Assertions, BadgeClasses or Profiles. These properties can typically be represented as just the <code>id</code> string of the image, but using a fleshed-out document allows for including captions and other applicable metadata.
+
+Property | Expected Type | Description
+---------|---------------|-----------
+type     | JSON-LD Type: [ImageObject](http://schema.org/ImageObject) ([Multiple values allowed](#array))| Defaults to schema:ImageObject.
+**id**   | IRI           | The URI or Data URI of the image.
+caption  | Text          | The caption for the image.
+author   | @id: Profile  | The author of the image, if desired.
+
+
+<h3 id="Criteria">Criteria</h3>
+
+(<a data-cite="OB-EXAMPLES#Criteria">example</a>)
+
+Descriptive metadata about the achievements necessary to be recognized with an <code>Assertion</code> of a particular <code>BadgeClass</code>. This data is added to the <code>BadgeClass</code> so that it may be rendered when that <code>BadgeClass</code> is displayed, instead of simply a link to human-readable criteria external to the badge. Embedding criteria allows either enhancement of an external criteria page or increased portability and ease of use by allowing issuers to skip hosting the formerly-required external criteria page altogether. 
+
+Criteria is used to allow would-be recipients to learn what is required of them to be recognized with an <code>Assertion</code> of a particular <code>BadgeClass</code>. It is also used after the <code>Assertion</code> is awarded to a recipient to let those inspecting earned badges know the general requirements that the recipients met in order to earn it.
+
+Property  | Expected Type | Description
+----------|---------------|-----------
+type      | JSON-LD Type  ([Multiple values allowed](#array))| Defaults to [Criteria](#Criteria).
+id        | IRI           | The URI of a webpage that describes in a human-readable format the criteria for the BadgeClass.
+narrative | Text or [Markdown Text](#MarkdownText) | A narrative of what is needed to earn the badge. 
+
+On the surface <code>Criteria</code> is a very simple class, but it enables some powerful use cases, such as using a Markdown-formatted <code>narrative</code> to draw the connections between multiple elements in an <code>alignment</code> array. The open nature of the Open Badges vocabulary allows experimentation with <a data-cite="OB-EXTENSIONS#">extensions</a> in <code>Criteria</code> as well, to let the market establish patterns for machine-readable criteria and automatic-awarding badge contracts.
+
+
+<h3 id="Alignment">AlignmentObject</h3>
+
+The AlignmentObject is an alias for schema.org's [AlignmentObject](http://schema.org/AlignmentObject) and uses IRIs from that vocabulary. See an <a data-cite="OB-EXAMPLES#BadgeClass">example</a> as it would appear in a BadgeClass document.
+
+Property | Expected Type | Description
+---------|---------------|-----------
+**targetName** | Text | Name of the alignment.
+**targetUrl** | URL | URL linking to the official description of the alignment target, for example an individual standard within an educational framework.
+targetDescription | Text | Short description of the alignment target.
+targetFramework | Text | Name of the framework the alignment target.
+targetCode | Text | If applicable, a locally unique string identifier that identifies the alignment target within its framework and/or <code>targetUrl</code>. 
+
+In order to render displays of alignment within badge services, <code>targetName</code> is required. In order to accurately identify targets, <code>targetUrl</code> is required. In the event that <code>targetUrl</code> cannot be specific enough to identify the item, <code>targetCode</code> may be used to indicate specifically which item within the targetUrl is the alignment target.
+
+**Note:** Open badges v1.x used <code>schema:name</code>, <code>schema:description, and </code>schema:url</code>. v2.0 updates the AlignmentObject to use the proper linked data IRIs from the Schema.org vocabulary. 
+
+
+<h3 id="RevocationList">Revocation List</h3>
+
+(<a data-cite="OB-EXAMPLES#RevocationList">example</a>)
+
+The Revocation List is a document that describes badges an Issuer has revoked that used the <code>signed</code> verification method. If you find the badge in the <code>revokedAssertions</code> list, it has been revoked. 
+
+An assertion reference may look like <code>{"id": "https://example.org/1", "revocationReason": "Violation of policy"}</code> or simply the string <code>"https://example.org/1"</code>. A UID-based reference may look like <code>{"uid": "abc123", "revocationReason": "Awarded in error"}</code>
+
+Property | Expected Type | Description
+---------|---------------|-----------
+**type** | JSON-LD Type ([Multiple values allowed](#array))| <code>RevocationList</code>.
+id       | IRI           | The <code>id</code> of the RevocationList.
+issuer   | IRI: Profile  | The <code>id</code> of the Issuer.
+**revokedAssertions** <a id="revokedAssertions"></a> | <code>Assertion</code> ([Multiple values allowed](#array)) | A string <code>id</code> or UID-based identification of a badge object that has been revoked.
+
+**Revoked Assertions referenced by revokedAssertions array:** Properties from [Assertion](#Assertion) in scope for those that have been revoked. Implementers generally only include these properties, clearing out the values that were in place before revocation. An identifying property must be used, either <code>id</code> or (legacy) <code>uid</code>. If the issuer does not wish to declare a revocation reason or additional metadata, the <code>id</code> of the <code>Assertion</code> may be included alone either as a single string entry to the list or in an object that defines an <code>id</code> property.
+
+Property | Expected Type | Description
+---------|---------------|-----------
+type     | JSON-LD Type ([Multiple values allowed](#array)) | Defaults to <code>Assertion</code>. May be omitted.
+id       | IRI           | The <code>id</code> of the revoked Assertion.
+uid      | Text          | Legacy identifier for pre-1.1 badges that did not use an IRI-based <code>id</code>.
+revoked  | Boolean | <code>true</code> if the Assertion is revoked. Defaults to true if present in a <code>revokedAssertions</code> list and may be omitted.
+revocationReason | Text | The published reason for revocation if desired.
+
+
+<h3 id="CryptographicKey">CryptographicKey</h3>
+
+(<a data-cite="OB-EXAMPLES#CryptographicKey">example</a>)
+
+Alias for the [Key](https://web-payments.org/vocabs/security#Key) class from the [W3C Web Payments Community Group Security Vocabulary](https://web-payments.org/vocabs/security). A CryptographicKey document identifies and describes a Key used for signing Open Badges documents. 
+
+For best compatibility with verification procedures, the <code>Profile</code> should be hosted at its HTTPS <code>id</code> and should identify a <code>publicKey</code> by the HTTPS <code>id</code> of a <code>CryptographicKey</code> document that identifies its issuer by the issuer's <code>id</code> using the <code>owner</code> property. This allows convenient and robust usage of these <code>id</code>s to identify both the issuer and the key used.
+
+Property | Expected Type | Description
+---------|---------------|-----------
+type     | JSON-LD Type ([Multiple values allowed](#array)) | <code>CryptographicKey</code>.
+id       | IRI           | The identifier for the key. Most platforms only support HTTP(s) identifiers.
+owner    | IRI: [Profile](#Profile) | The identifier for the Profile that owns this key. There should be a two-way connection between this Profile and the CryptographicKey through the <code>owner</code> and <code>publicKey</code> properties.
+publicKeyPem | Text      | The PEM key encoding is a widely-used method to express public keys, compatible with almost every Secure Sockets Layer library implementation.
+
+## Properties
+Below are listed several properties usable across several Classes. They are optional in all cases.
+
+### related
+The <code>related</code> property identifies another entity of the same type that should be considered the same for most purposes. It is primarily intended to identify alternate language editions or previous versions of BadgeClasses. See examples: <a data-cite="OB-EXAMPLES#Internationalization">alternate language versions</a> and <a data-cite="OB-EXAMPLES#badgeclass-version-control">BadgeClass version control</a>.
+
+### version
+The <code>version</code> property allows issuers to specify a version string or number. It is primarily used to update a BadgeClass without changing the meaning of previously awarded Assertions by duplicating and linking to the previous version. See <a data-cite="OB-EXAMPLES#badgeclass-version-control">example</a>.
+
+Property | Expected Type | Description
+---------|---------------|-----------
+related  | @id ([Multiple values allowed](#array)) | Identifies a related version of the entity.
+version  | Text or Number | The version identifier for the present edition of the entity.
+endorsement | @id: [Endorsement](#Endorsement) Multiple values allowed) | A claim made about this entity. Note: As endorsements must be published after the publication of the entity they endorse, it will not always be possible to establish a two-way linkage with this property.
+
+
+<h2 id="ProfileIdentifierProperties">Profile Identifier Properties</h2>
+
+When profiles are referenced elsewhere in the Open Badges Specification, they may be identified precisely by dereferencable id, such as when a BadgeClass links to an issuer Profile by its <code>id</code> URL. Other times, such as when identifying the [recipient](#recipient) of an [Assertion](#Assertion), Profiles may be identified by the value of a specific property unique to the individual or organization represented in a Profile. All properties that serve as profile identifiers must have values with a string datatype.
+
+**Properties considered serviceable identifiers include:**
+
+* <code>email</code>
+* <code>url</code>
+* <code>telephone</code>
+
+Many platforms that allow badge issuers and recipients to establish their identities as Profiles support only <code>email</code> (<code>https://schema.org/email</code>) as an identifier property.
+
+
+<h2 id="Extensions">Extensions</h2>
+
+The 1.1 version of the Open Badges Specification introduces Extensions as a means for issuers to add additional metadata to Badge Objects beyond what the standard specifies itself. Additional properties are allowed without using Extensions, but Extensions allow issuers to declare how they are adding information so that it can be understood by others and other issuers can add the same sort of information in a compatible way.
+
+See the [[[OB-EXTENSIONS]]] page for specific examples and extensions ready to use in Badge Objects.
+
+Extension authors define and host a new [[JSON-LD]] context file describing all the terms the extension covers. These context files may further define any [JSON-schema](http://json-schema.org/) that implementations of the extension should pass. If used, each schema is linked from the context and hosted as a separate JSON-schema files. Extensions are implemented in Open Badges as JSON objects inside an Assertion, BadgeClass or Issuer with their own link to the extension context and declaration of type.
+
+Property | Expected Type | Description
+--------|------------|-----------
+**@context** | URL | JSON-LD context file shared among all implementations of the extension.
+**type** | IRI ([Multiple values allowed](#array)) | IRI or compact IRI within the OBI or extension context that describe the type of data contained in the extension. The IRI is used to map optional JSON-schema validation to the extension. Must include 'extension' as one element.
+\*anyProperties | Any | Any property names defined in the extension context may be used with any valid JSON value. 
+
+An extension value should be included as a JSON object containing the <code>@context</code> and <code>@type</code> properties and any new properties whose names are mapped in the context file referenced by <code>@context</code>. 
+
+The property name for the extension should map to an IRI within the <code>@context</code> defined at the root of the extended Badge Object. It is possible to use a fully qualified IRI (e.g. <code>http://example.org/newBadgeExtension</code>) or a compact IRI within the extension namespace defined in the <a data-cite="OB-JSONLD-20#">OBI context</a>, like <code>extension:newBadgeExtension</code>. In either case, the IRI should correspond to where a human-readable definition of the extension resides. For extensions using the <code>extension</code> namespace, this definition may be contributed to the community <a data-cite="OB-EXTENSIONS#">extensions repository</a> on this site.
+
+See <a data-cite="OB-EXTENSIONS#">example extensions</a>.
+
+
+<h3 id="validation">Extension Validation</h3>
+
+Open Badges v1.1 implements an optional JSON-schema based mechanism of ensuring badge objects conform to syntactic requirements of the specification. JSON-schema can ensure that required properties exist and that expected data types are used. From the <a data-cite="OB-JSONLD-20#">context</a>s for badge objects and extensions, a <code>validation</code> [array](#array) may contain links to various JSON-schema against which badge objects may be tested. There are two proposed methods of specifying which component of a badge object should be matched against the JSON-schema validator: TypeValidation and FrameValidation. As of 1.1, only TypeValidation is implemented.
+
+For example, this portion of the current Open Badges context links to a validator for Assertions. It indicates through TypeValidation that it should be run against JSON objects with the JSON-LD type of <code>Assertion</code> ([https://w3id.org/openbadges#Assertion]).
+<pre>
+{
+  ...
+  "validation": [
+    {
+      "type": "TypeValidation",
+      "validatesType": "Assertion",
+      "validationSchema": "https://openbadgespec.org/v1/schema/assertion.json"
+    },
+    ...
+  ]
+}
+</pre>
+
+
+<h4 id="TypeValidation">Type Validation</h4>
+
+Validators using the TypeValidation method match the schema indicated by the validator's <code>validationSchema</code> property against a JSON badge object document or portion of such a document that matches the validator's <code>validatesType</code> JSON-LD <code>type</code>.
+
+Property | Expected Type | Description/expected value
+--------|------------|-----------
+**type** | string/compact IRI ([Multiple values allowed](#array)) | <code>TypeValidation</code>.
+**validatesType** | string/compact IRI | Valid JSON-LD type for a badge component, such as <code>Assertion</code>, <code>extensions:ApplyLink</code>, or <code>https://w3id.org/openbadges/extensions#ApplyLink</code>. Compact forms preferred.
+**validationSchema** | URL | Location of a hosted JSON-schema.
+
+
+<h4 id="FrameValidation">Frame Validation</h4>
+
+_status: proposed_
+
+Validators that someday use the proposed FrameValidation method pass JSON-LD objects through the JSON-LD Frame indicated by the <code>validationFrame</code> property and test the result against the JSON-schema indicated by the validator's <code>validationSchema</code> property.
+
+
+<h2 id="Endorsement">Endorsement</h2>
+
+(<a data-cite="OB-EXAMPLES#Endorsement">example</a>)
+
+Open Badges are trustworthy records of achievement. The vocabulary defined above, combined with the validation and verification procedures for badge Assertions, establish Open Badges as a reliable method for expressing and verifying achievements online. However, these procedures don't answer questions like, "Who trusts this BadgeClass to be a good certification of the competency it describes?" or, "Is this Profile's email address verified?" For these questions, there is Endorsement.
+
+Endorsement leans on the Verifiable Claims work prototyped by members of the [Verifiable Claims Task Force](https://w3c.github.io/vctf/) at the [W3C](https://www.w3.org/) and the theoretical backing developed by the 2014 Endorsement Working Group. See [Endorsement Framework Paper](https://docs.google.com/document/d/1VVf19d72KmGMh1ywrLe7HCKEOqGSI0WjvwfGN_8Q2M4/edit#heading=h.xyxfmzqz2vqb).
+
+The <code>Endorsement</code> Class is very similar to <code>Assertion</code>, except that there is no defined <code>badge</code> property. Instead, a <code>claim</code> property allows endorsers to make specific claims about other <code>Profiles</code>, <code>BadgeClasses</code>, or <code>Assertions</code>.
+
+Property | Expected Type | Description/expected value
+---------|---------------|-----------
+**id**   | IRI           | Unique IRI for the Endorsement instance. If using hosted verification, this should be the URI where the assertion of endorsement is accessible. For signed Assertions, it is recommended to use a UUID in the urn:uuid namespace.
+**type** | JSON-LD Type ([Multiple values allowed](#array)) | <code>Endorsement</code>, a subclass of VCTF's Credential.
+**claim**    | @id           | An entity, identified by an <code>id</code> and additional properties that the endorser would like to claim about that entity.
+**issuer** | @id: Profile | The profile of the Endorsement's issuer.
+**issuedOn** | [DateTime](#dateTime) | Timestamp of when the endorsement was published.
+**verification** | [VerificationObject](#VerificationObject) | Instructions for third parties to verify this assertion of endorsement.
+
+Within the <code>claim</code> property, the endorsed entity may be of any type (though only Open Badges Vocabulary classes are expected to be understood by Open Badges-specific tools. While <code>Endorsement</code> is a very flexible data structure, its usefulness will be limited not by the creativity of endorsers, but by the ability for other tools to discover and understand those endorsements.
+
+There is one special property for use in endorsement, the <code>endorsementComment</code>, which allows endorsers to make a simple claim in writing about the entity.
+
+Property | Expected Type | Description/expected value
+---------|---------------|-----------
+endorsementComment | Text or [Markdown](#MarkdownText) | An endorser's comment about the quality or fitness of the endorsed entity.
+
+Endorsements use the <code>claim</code> property to identify another entity by its <code>id</code> and declare properties about it. For example, the following allows an issuer to offer their own claim that an email address belongs to the profile identified as <code>https://otherissuer.example/1</code> and make a comment about the quality of their badges.
+<pre>
+{
+ "@context": "https://w3id.org/openbadges/v2",
+ "type": "Endorsement",
+ "id": "https://example.org/assertions/123",
+ "issuer": "https://example.org/issuer",
+ "claim": {
+   "id": "https://otherissuer.example/1",
+   "email": "contact@otherissuer.example",
+   "endorsementComment": "A great provider of badged learning."
+ },
+ "verification": {
+   "type": "hosted"
+ }
+}
+</pre>
+<a data-cite="OB-EXAMPLES#Endorsement">See more examples</a>
+
+
+<h2 id="addtional">Additional Properties</h2>
+
+Badges consist of sets of claims, properties with values that apply to Profiles, all earners of a badge, or individual badge recipients. Outside of extensions, additional properties may be added to these claim sets so long as they are mapped to an IRI as JSON-LD. For example, publishers of Badge Objects may:
+
+1. Add individual mappings to the Badge Object's context: <code>"@context":["https://w3id.org/openbadges/v2", {"foo": "http://example.org/foo"}]</code>
+2. Link to additional context files in the Badge Object's context: <code>"@context":["https://w3id.org/openbadges/v2", "http://example.org/context"]</code>
+3. Add new properties using full IRIs as keys (or with compact IRIs valid in the existing context): <code>"http://example.org/foo":"bar"</code> or <code>"schema:comment":"baz"</code> where the IRI leads to the vocabulary definition for the term.
+
+Processors should preserve properties that are valid data when rehosting or retransmitting, but it is permissible to perform valid JSON-LD transformations. Such transformations include "expanding", "compacting" and modifying the context. Transformations are assumed to be equivalent if the expanded or normalized RDF value of the new version is semantically equivalent to the expanded value of the original.
+
+If a property would be useful beyond a publisher's internal use, an [Extension](#Extensions) is a recommended way to establish common practice for adding certain sets of information to badge objects.
+
+
+## <a id="datatypes"></a>Primitive datatypes
+
+* <a data-cite="RFC4627#boolean" id="boolean">Boolean</a> - A JSON boolean value as defined in [[RFC4627]]
+* <a data-cite="RFC4627#string" id="text">Text</a> - A JSON string value as defined in [[RFC4627]]
+* <a data-cite="RFC4627#array" id="array">Array</a> - A JSON array as defined in [[RFC4627]]. Arrays are used for all properties where multiple values are allowed when multiple values are used. Each entry in the array must match the type requirement specified for that property.
+* <a data-cite="ISO8601#dateTime" id="dateTime">DateTime</a> - Open Badges must express timestamps as strings compatible with [[ISO8601]] guidelines, including the time and a time zone indicator. It is recommended to publish all timestamps in UTC. Previous versions of Open Badges allowed Unix timestamps as integers. Open Badges v2.0 requires string ISO 8601 values with time zone indicators. For example, <code>2016-12-31T23:59:59+00:00</code> is a valid ISO 8601 timestamp. It contains the year, month, day, <code>T</code> separator, hour number 0-23, minute, optional seconds and decimal microsecond, and a time zone indicator (+/- an offset from UTC or the <code>Z</code> designator for UTC).
+* URL - Fully qualified URL, including protocol, host, port if applicable, and path. Interpreters are only expected to interpret URLs in either the <code>http</code> or <code>https</code> schemes.
+* IRI - In JSON-LD and Linked Data, IRIs (Internationalized Resource Identifiers) may look like fully qualified URLs or be namespaced within the JSON-LD context to be expanded to a full IRI. The only known supported IRI schemes are <code>http</code> and <code>https</code>.
+* <a id="identityHash"></a>IdentityHash - A hash string preceded by a dollar sign ("$") and the algorithm used to generate the hash. The supported algorithms are [MD5](https://www.ietf.org/rfc/rfc1321.txt) and [SHA-256](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf), identified by the strings <code>md5</code> and <code>sha256</code> respectively. For example: <code>sha256$28d50415252ab6c689a54413da15b083034b66e5</code> represents the result of calculating a SHA-256 hash on the string "mayze". For more information, see [how to hash & salt in various languages](https://github.com/mozilla/openbadges/wiki/How-to-hash-&-salt-in-various-languages.).
+* <a id="MarkdownText"></a> Markdown Text - Text that may contain formatting according to [Markdown syntax](https://daringfireball.net/projects/markdown/syntax). Due to uneven support in displayers, publishers are encouraged to limit usage to simple elements like links, emphasis, and lists. Displayers may choose a subset of Markdown formatting to support or how to render this field. Images and tables may or may not be supported.
+
+
+# Implementation
+
+
+## Publishing Badge Objects
+Open Badges data is published as JSON-LD documents made up of the above data classes. These link together via use of common identification strings and properties. They rely on other data, including image files that are often hosted on HTTP(s) URIs outside of the JSON-LD documents that describe them.
+
+
+### Setting Content-Type
+Badge Objects encoded in JSON-LD should be served with the <code>application/ld+json</code> content type by default. If the request indicates only <code>application/json</code> as the <code>Accept</code> type, responses should include <code>application/json</code> in the response content type. If request is made for <code>text/html</code> or other content-type above <code>application/ld+json</code> or <code>application/json</code>, the requested content-type may be returned.
+
+
+<h3 id="Baking">Badge Baking</h3>
+
+Badge assertions may be "baked" into image files as portable credentials. Baking is currently supported for PNG and SVG formats. (See [[[OB-BAKE-10]]] for implementation)
+
+
+## Data Validation
+Data Validation is a procedure that ensures a cluster of Badge Objects that make up an Open Badge are appropriately published and linked, and that each particular instance of a Badge Object conforms to requirements for its class. Validation of all data class instances used in an Open Badge is a part of badge verification.
+
+Validation includes tests to ensure that:
+
+* All required Badge Objects are appropriately linked and available to the validator with an eventual <code>200 OK</code>.
+* Any relevant optional Badge Objects that are linked (such as <code>RevocationList</code>s) are available.
+* Each Badge Object is a valid JSON-LD (Linked Data) document.
+* Each Badge Object contains all required properties for its class.
+* Each Badge Object contains values of the expected data type for all declared properties defined in the Vocabulary.
+
+The use of the term "eventual 200 OK" is meant to mean that 3xx
+redirects are allowed, as long as the request eventually terminates on an appropriate
+resource that returns a 200 OK.
+
+
+<h2 id="implementation-verification">Verification</h2>
+
+Verification is the process of ensuring the data that makes up an Open Badge is correct for the purpose at hand. It includes a number of data validation checks as well as procedures to ensure the badge is trustworthy. Verification is distinct from Compliance Certification for applications and services that implement the Specification, though verification is typically a component of certification programs.
+
+Verification includes tests to ensure that:
+
+* All Badge Objects pass data validation. See [Data Validation](#data-validation) above.
+* All Badge Objects were created by the appropriate issuer <code>Profile</code>(s) according to rules declared in their [VerificationObjects](#VerificationObject).
+* The <code>Assertion</code> was awarded to a valid property value of the expected recipient. (For example, that the <code>Asssertion</code> was awarded to a known email address value for <code>email</code> type recipient <code>IdentityObject</code>.)
+* The <code>Assertion</code> issuer is authorized to award Assertions of the declared <code>BadgeClass</code> (typically by being the issuer of the BadgeClass.)
+* The <code>Assertion</code> has not expired.
+* The <code>Assertion</code> has not been revoked by the issuer.
+
+Additional checks may ensure that:
+
+* The issuer Profile awarding the Assertion is trusted to have declared accurate information about its identity (typically via Endorsement).
+
+
+<h3 id="HostedBadge">HostedBadge Verification</h3>
+
+A hosted Assertion is a file containing validated <code>Assertion</code> data in JSON-LD served with the content-type <code>application/ld+json</code> and/or <code>application/json</code>. This should be available to anyone who the recipient would like to be able to verify it at a stable URI on your server (for example, <code>https://example.org/assertions/robotics-badge/123.json</code>). This URI is the source of truth for the badge, and any verification attempt will request it to make sure the Assertion exists and describes the expected achievement. Redirects are permissible as long as appropriate Assertion content is eventually returned. The hosting application must properly [set the content-type](#setting-content-type).
+
+The Assertion <code>id</code> must be within the permitted scope for hosted verification declared in issuer Profile. See [VerificationObject](#VerificationObject). This defaults to requiring the Assertion and BadgeClass to be hosted on the same origin as the issuer Profile <code>id</code> if there is no <code>verification</code> property declared in the issuer Profile. For domain origins that host multiple applications and websites, <code>startsWith</code> path may be used, in which case, the <code>verificationProperty</code> (<code>id</code>) must start with the value found in the issuer Profile's VerificationObject <code>startsWith</code> declaration.
+
+**Steps to verify a hosted badge Assertion**:
+Verification of hosted assertions may be performed starting with the verification URL or with a full Assertion instance in hand. If starting with a full assertion that indicates <code>HostedBadge</code> verification, the input data should only be trusted to identify the URI of the hosted verification file, and upon loading the hosted verification file, the retrieved data should be used as the Assertion value.
+
+
+#### Revoking Hosted Assertions 
+
+(<a data-cite="OB-EXAMPLES#revoked-hosted-assertion">example</a>)
+
+To mark a hosted assertion as revoked, respond with an HTTP Status of <code>410 Gone</code>. The response may include an <code>Assertion</code> body containing some additional metadata, such as a <code>revocationReason</code>, but it is not required to meet all normal property presence requirements. For revoked Assertions, only <code>id</code> and <code>revoked</code> are required.
+
+If either the <code>410 Gone</code> status or a response body declaring <code>revoked</code> true is returned, the Assertion should be treated as revoked and thus invalid.
+
+
+<h3 id="SignedBadge">SignedBadge Verification</h3>
+
+(<a data-cite="OB-EXAMPLES#SignedBadge">example</a>)
+
+A signed badge may be published in the form of a [[[rfc7515]]]. If so, the JSON representation of the badge assertion should be used as the JWS payload. 
+
+A JWS has three components separated by dots (<code>.</code>):
+<pre>
+header.payload.signature
+</pre>
+
+The JSON-LD representation of the <code>Assertion</code> should be used as the JWS payload. For compatibility purposes, using RSA-SHA256 is recommended.
+
+The public key corresponding to the private key used to the sign the badge should be publicly accessible via HTTP and specified in the issuer Profile's <code>publicKey</code> property. If there are multiple keys declared in the issuer Profile, the Assertion's <code>VerificationObject</code> may specify the <code>id</code> of the public key that should be used for verification with its <code>creator</code> property.
+
+**Steps to verify a JWS-signed badge Assertion**:
+
+1. Base64 decode the JWS payload. This will be a JSON string representation of the badge assertion.
+2. Parse the decoded JWS body into a JSON object. If the parsing operation fails, assertion MUST be treated as invalid.
+3. Perform data validation on the Assertion and the (embedded or linked) BadgeClass and issuer Profile, as well as any other relevant present data.
+4. Determine the correct signing key <code>id</code>(s) to test against the signature from the valid issuer Profile and Assertion VerificationObject. Do not trust a key that is not properly linked from the issuer Profile.
+5. Perform an HTTP GET request on the trusted keys. If it is impossible to get a usable public key, the Assertion cannot be verified.
+6. With each trusted public key, perform a JWS verification on the JWS object. If the verification fails, assertion MUST be treated as invalid.
+7. Retrieve the revocation list from the Issuer Profile object if present and ensure the <code>id</code> of the badge does not appear in the <code>revokedAssertions</code> list. Legacy v1.x badges that lack a <code>id</code> property may be identified in this list by their <code>uid</code>.
+8. If the above steps pass, assertion may be treated as valid.
+
+Other signature suites may be later included in this document if they are investigated and approved.
+
+#### Revoking a Signed Badge
+
+To mark a badge as revoked, add an entry to the resource pointed at by the Issuer Profile <code>revocationList</code> URL with the **id** of the Assertion and, optionally, a reason why the badge is being revoked. See an <a data-cite="OB-EXAMPLES#RevocationList">example</a>.
+
+<div></div>
+`;

--- a/ob_v2p0/shared/contributors.js
+++ b/ob_v2p0/shared/contributors.js
@@ -1,0 +1,23 @@
+var _contributors = [
+    { name: "Sara Arjona", company: "Moodle" },
+    { name: "Jeff Bohrer", company: "IMS Global" },
+    { name: "Timothy F. Cook", company: "LRNG" },
+    { name: "Maria Esquela", company: "eNABLE Community" },
+    { name: "Steve Gance", company: "Washington State Board for Community and Technical Colleges" },
+    { name: "Jim Goodell", company: "QIP/CEDS" },
+    { name: "Markus Gylling", company: "IMS Global" },
+    { name: "Viktor Haag", company: "D2L" },
+    { name: "Takahiro Hata", company: "Digital Knowledge EdTech Lab" },
+    { name: "Alexander Hripak", company: "Credly", role: "Editor" },
+    { name: "Chris Houston", company: "eLumen" },
+    { name: "Kerrie Lemoie", company: "OpenWorks Group" },
+    { name: "Mark Leuba", company: "IMS Global" },
+    { name: "Randy Macdonald", company: "Innovation Academy / InnovateOregon" },
+    { name: "Omid Mufeed", company: "Digitalme" },
+    { name: "Nate Otto", company: "Concentric Sky" },
+    { name: "Justin Pitcher", company: "Campus Labs" },
+    { name: "Serge Ravet", company: "ADPIOS, BadgeEU" },
+    { name: "Alex Reis", company: "D2L" },
+    { name: "Jarin Schmidt", company: "Pearson Acclaim" },
+    { name: "Attila Szabo-Nagy", company: "Erasmus+" }
+];

--- a/ob_v2p0/shared/iprs.js
+++ b/ob_v2p0/shared/iprs.js
@@ -1,0 +1,9 @@
+var _iprs = [
+    { specVersion: "2.0", company: "Campus Labs", electionDate: "March 20, 2019", necessaryClaims: "No", type: "RF RAND (Required & Optional Elements)" },
+    { specVersion: "2.0", company: "Mozilla Foundation", electionDate: "March 14, 2019", necessaryClaims: "No", type: "RF RAND (Required & Optional Elements)" },
+    { specVersion: "2.0", company: "Credly", electionDate: "March 14, 2019", necessaryClaims: "No", type: "RF RAND (Required & Optional Elements)" },
+    { specVersion: "2.0", company: "Digitalme", electionDate: "March 11, 2019", necessaryClaims: "No", type: "RF RAND (Required & Optional Elements)" },
+    { specVersion: "2.0", company: "D2L Corporation", electionDate: "March 10, 2019", necessaryClaims: "No", type: "RF RAND (Required & Optional Elements)" },
+    { specVersion: "2.0", company: "Credly", electionDate: "March 18, 2018", necessaryClaims: "No", type: "RF RAND (Required Elements)" },
+    { specVersion: "2.0", company: "Pearson", electionDate: "November 21, 2017", necessaryClaims: "No", type: "RF RAND (Required Elements)" }
+];

--- a/ob_v2p0/shared/localBiblio.js
+++ b/ob_v2p0/shared/localBiblio.js
@@ -1,0 +1,64 @@
+var _localBiblio = {
+    "OB-BAKE-10": {
+        title: "Open Badges Baking Specification v1.0",
+        href: "https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/baking/",
+        date: "April 16, 2018",
+        publisher: "IMS Global"
+    },
+    "OB-CERT-20": {
+        title: "Open Badges Conformance and Certification Guide v2.0",
+        href: "https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/cert/",
+        date: "April 12, 2018",
+        publisher: "IMS Global",
+        authors: [
+            "Jeff Bohrer",
+            "Timothy F. Cook",
+            "Steve Gance",
+            "Markus Gylling",
+            "Alex Hripak",
+            "Nate Otto",
+            "Justin Pitcher",
+            "Alex Reis",
+            "Jarin Schmidt"
+        ]
+    },
+    "OB-EXAMPLES": {
+        title: "Open Badges Examples",
+        href: "https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/examples/",
+        date: "April 12, 2018",
+        publisher: "IMS Global"
+    },
+    "OB-EXTENSIONS": {
+        title: "Open Badges Extensions",
+        href: "https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/extensions/",
+        publisher: "IMS Global"
+    },
+    "OB-IMPL-20": {
+        title: "Open Badges Implementation Guide v2.0",
+        href: "https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/impl/",
+        date: "October 18, 2018",
+        publisher: "IMS Global",
+        authors: [
+            "Jeff Bohrer",
+            "Timothy F. Cook",
+            "Steve Gance",
+            "Markus Gylling",
+            "Alex Hripak",
+            "Nate Otto",
+            "Justin Pitcher",
+            "Alex Reis",
+            "Jarin Schmidt"
+        ]
+    },
+    "OB-JSONLD-20": {
+        title: "Open Badges JSON-LD Context File v2.0",
+        href: "http://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/v2/context.json",
+        date: "August 29, 2019",
+        publisher: "IMS Global",
+        authors: [
+            "Jeff Bohrer",
+            "Alex Hripak",
+            "Nate Otto"
+        ]
+    }
+};

--- a/ob_v2p0/shared/ob-abstract.md
+++ b/ob_v2p0/shared/ob-abstract.md
@@ -1,0 +1,6 @@
+var abstract = `
+
+## Abstract
+Open Badges are visual symbols of accomplishments packed with verifiable metadata according to the Open Badges specification. The Open Badges specification defines the properties necessary to define an achievement and award it to a recipient, as well as procedures for verifying badge authenticity and “baking” badge information into portable image files. It includes term definitions for representations of data in Open Badges. These term definitions appear in the current [[[OB-JSONLD-20]]].
+
+`;        

--- a/ob_v2p0/shared/ob-documents.md
+++ b/ob_v2p0/shared/ob-documents.md
@@ -1,0 +1,15 @@
+var documents = `
+
+### Specification Documents
+
+The full set of documents is comprised of the following documents:
+
+* [[[OB-20]]]
+* [[[OB-IMPL-20]]]
+* [[[OB-CERT-20]]]
+* [[[OB-BAKE-10]]]
+* [[[OB-JSONLD-20]]]
+* [[[OB-EXAMPLES]]]
+* [[[OB-EXTENSIONS]]]
+
+`;        

--- a/ob_v2p0/shared/ob-terms.md
+++ b/ob_v2p0/shared/ob-terms.md
@@ -1,0 +1,20 @@
+var terms = `
+
+### Terminology
+The following terms are used throughout this document.
+
+- **Assertion**: A representation of an awarded badge, used to share information about a badge belonging to one recipient.
+- **Backpack**: A term originally used to describe Open Badges services that provide importing, aggregation, and hosting features for recipients. These services match most closely with the role we now define as an Open Badge “Host” application. May also refer to the Mozilla Backpack.
+- **BadgeClass**: A collection of information about the accomplishment recognized by the Open Badge. Many assertions may be created corresponding to one BadgeClass.
+- **Badge Issuer**: A service that allows for the creation of BadgeClasses and the subsequent issuing of Assertions to recipients that conform to the Open Badges specification. Beginning with Open Badges 2.0, the candidate platform must issue a valid baked badge and demonstrate how the badge is retrieved by the recipient.
+- **Badge Displayer**: An application that displays verified badges to viewers. Beginning with Open Badges 2.0, the candidate platform must display a minimum set of badge metadata and support viewer-initiated verification of a badge.
+- **Badge Host**: An application that can import, aggregate, and publicly host Assertions for recipients. It also supports export of badges at user request. Beginning with Open Badges 2.0, the candidate platform must be able to import all formats of Open Badges as well as prove that badge metadata is not lost upon export of the badge.
+- **Baked badge**: Badge Assertions may be “baked” into image files as portable credentials.
+- **Candidate platform**: A platform implementing the Open Badges specification with the intent to obtain certification from IMS. They may be in the process to obtain certification.
+- **Criteria**: Detailed information about what must be done in order to be recognized with an assertion of a particular BadgeClass. Potential recipients may use criteria to understand what they must do; consumers may use criteria to understand what recipients did in order to earn the badge.
+- **Evidence**: Links to and descriptions of evidence related to the issuance of an Assertion, such as portfolio items or narratives that describe a badge recipient's work.
+- **Extensions**: Extensions are a means for issuers to add additional functionality through the use of metadata on Badge Objects beyond what the standard specifies itself.
+- **Validation and verification (of badge assertions)**: Data validation is a procedure that ensures a cluster of data objects that form an Open Badge are appropriately formatted, published, and linked and that each data object conforms to requirements for its class. Validation of all data class instances used in an Open Badge is a part of badge verification. Verification is the process of ensuring the data that makes up an Open Badge is correct. It includes a number of data validation checks as well as procedures to ensure the badge is trustworthy. Verification is distinct from compliance certification for applications and services that implement the specification, though verification is typically a component of certification programs. See <a href="OB-SPEC-21#Verification">Verification</a> in the current specification.
+
+<div></div>
+`;


### PR DESCRIPTION
Fixes #250 

In scope:
- Specification
- Baking
- Certification
- Implementation
- Examples

Out of scope:
- Extensions

Breaking Changes
- Because IMS Respec generates front matter including Current, Latest, and Errata, the Respec documents will need to be published to a different location. For example,
![image](https://user-images.githubusercontent.com/48326098/67432045-5cab2700-f59a-11e9-95f2-c8d23bd92510.png)
