### PR TITLE
Set extensions as public; update typos

### DIFF
--- a/ob_v2p0/extensions/assessmentExtension/index.html
+++ b/ob_v2p0/extensions/assessmentExtension/index.html
@@ -8,7 +8,7 @@
       specTitle: "Open Badges Assessment Extension",
       shortName: "ob-assessment",
       specStatus: "IMS Candidate Final Public",
-      specDate: "April 12th, 2018",
+      specDate: "October 7th, 2020",
       specNature: "normative",
       specVersion: "1.0",
       specType: "spec",

--- a/ob_v2p0/extensions/assessmentExtension/index.html
+++ b/ob_v2p0/extensions/assessmentExtension/index.html
@@ -7,7 +7,7 @@
     var respecConfig = {
       specTitle: "Open Badges Assessment Extension",
       shortName: "ob-assessment",
-      specStatus: "IMS Candidate Final",
+      specStatus: "IMS Candidate Final Public",
       specDate: "April 12th, 2018",
       specNature: "normative",
       specVersion: "1.0",
@@ -552,15 +552,21 @@
         </thead>
         <tbody>
           <tr>
-            <td>Working Document 1.0</td>
-            <td>January 1st, 2017</td>
-            <td>Initial proof of concept.</td>
+            <td>Candidate Final Public</td>
+            <td>October 7, 2020</td>
+            <td>Release extension as public</td>
           </tr>
-          <tr>
+           <tr>
             <td>Candidate Final</td>
             <td>April 12th, 2018</td>
             <td>Update to include Rubric, Section, and Question</td>
           </tr>
+          <tr>
+            <td>Working Document 1.0</td>
+            <td>January 1st, 2017</td>
+            <td>Initial proof of concept.</td>
+          </tr>
+        
         </tbody>
       </table>
     </section>

--- a/ob_v2p0/extensions/extraDescription/index.html
+++ b/ob_v2p0/extensions/extraDescription/index.html
@@ -7,7 +7,7 @@
      var respecConfig = {
        specTitle: "Open Badges Extra Description Extension",
        shortName: "ob-exdesc",
-       specStatus: "IMS Base Document",
+       specStatus: "IMS Candidate Final Public",
        specDate: "April 12th, 2018",
        specNature: "normative",
        specVersion: "1.0",
@@ -96,7 +96,7 @@
         <table class="data">
           <tr><th>Property</th><th>Type</th><th>Value Description</th></tr>
           <tr><td>@context</td><td>IRI</td>
-            <td><code>http://purl.imsglobal.org/spec/ob-exdesc/v1p0/context/</code> 
+            <td><code>https://purl.imsglobal.org/spec/ob-exdesc/v1p0/context/</code> 
               (required)</td></tr>
           <tr><td>type</td><td>JSON-LD Type Array</td>
             <td><code>["Extension", "extensions:ExtraDescriptionExtension"]</code>
@@ -121,7 +121,7 @@
           <pre class="scroll"><code>
 {
   "extensions:extraDescription": {
-    "@context":"http://purl.imsglobal.org/spec/ob-exdesc/v1p0/context/",
+    "@context":"https://purl.imsglobal.org/spec/ob-exdesc/v1p0/context/",
     "type": ["Extension", "extensions:ExtraDescriptionExtension"],
     "name": "Related Roller Coasters",
     "narrative": "Here are two roller coasters that will give you a similar experience to undergoing assessment for this badge.\n\n* [Tempesto](https://www.youtube.com/watch?v=ZCKhkRPq8rI), Busch Gardens, Williamsburg\n* [Fantasia Mini Special Kiddie Roller Coaster](https://www.youtube.com/watch?v=bisz3CJZDpA), Tongdo Fantasia, South Korea"
@@ -142,12 +142,12 @@
           <pre class="scroll"><code>
 {
   "extensions:extraDescription": [{
-    "@context":"http://purl.imsglobal.org/spec/ob-exdesc/v1p0/context/",
+    "@context":"https://purl.imsglobal.org/spec/ob-exdesc/v1p0/context/",
     "type": ["Extension", "extensions:ExtraDescriptionExtension"],
     "name": "Related Roller Coasters",
     "narrative": "Here are two roller coasters that will give you a similar experience to undergoing assessment for this badge.\n\n* [Tempesto](https://www.youtube.com/watch?v=ZCKhkRPq8rI), Busch Gardens, Williamsburg\n* [Fantasia Mini Special Kiddie Roller Coaster](https://www.youtube.com/watch?v=bisz3CJZDpA), Tongdo Fantasia, South Korea"
   },{
-    "@context":"http://purl.imsglobal.org/spec/ob-exdesc/v1p0/context/",
+    "@context":"https://purl.imsglobal.org/spec/ob-exdesc/v1p0/context/",
     "type": ["Extension", "extensions:ExtraDescriptionExtension"],
     "name": "Related Poem",
     "narrative": "Badges may be round, \nmore commonly hexes, \nThey've got great illustrations, \nSometimes of T-Rexes.\n\nSee this [example badge image](http://hexb.in/hexagons/offline-trex.png)."
@@ -170,7 +170,12 @@
                   <tr><th>Version No.</th><th>Release Date</th><th>Comments</th></tr>
                 </thead>
                   <tbody>
-                      <tr>
+                     <tr>
+                          <td>Candidate Final Public</td>
+                          <td>October 7, 2020</td>
+                          <td>Release as public document.</td>
+                      </tr> 
+                    <tr>
                           <td>Base Document 1.0</td>
                           <td>April 12th, 2018</td>
                           <td>Initial release.</td>

--- a/ob_v2p0/extensions/extraDescription/index.html
+++ b/ob_v2p0/extensions/extraDescription/index.html
@@ -8,7 +8,7 @@
        specTitle: "Open Badges Extra Description Extension",
        shortName: "ob-exdesc",
        specStatus: "IMS Candidate Final Public",
-       specDate: "April 12th, 2018",
+       specDate: "October 7th, 2020",
        specNature: "normative",
        specVersion: "1.0",
        specType: "spec",

--- a/ob_v2p0/extensions/index.md
+++ b/ob_v2p0/extensions/index.md
@@ -51,7 +51,7 @@ Assertion, BadgeClass, Issuer
 
 2. [Assessment](https://www.imsglobal.org/spec/ob-assessment/v1p0/) - This extension allows issuers to embed metadata about assessment(s) performed in the badge awarding process, potentially including some questions and related rubric data. 
 
-3. [Extra Description](http://imsglobal.github.io/openbadges-specification/extensions/extraDescription/) - Allows issuers to add additional descriptive fields to a BadgeClass or Issuer Profile.
+3. [Extra Description](https://www.imsglobal.org/spec/ob-exdesc/v1p0/) - Allows issuers to add additional descriptive fields to a BadgeClass or Issuer Profile.
 
 ---
 

--- a/ob_v2p0/extensions/issuerAccreditationExtension/index.html
+++ b/ob_v2p0/extensions/issuerAccreditationExtension/index.html
@@ -7,7 +7,7 @@
     var respecConfig = {
       specTitle: "Open Badges Issuer Accreditation Extension",
       shortName: "ob-accred",
-      specStatus: "IMS Candidate Final",
+      specStatus: "IMS Candidate Final Public",
       specDate: "April 12th, 2018",
       specVersion: "1.0",
       specNature: "normative",
@@ -266,6 +266,31 @@
 </code></pre>
     </section>
   </section>
+  
+   <section class="appendix informative" id="revision-history">
+        <h2>Revision History</h2>        
+          <section>
+            <h3>Version History</h3>
+              <table title="Revision History" class="data"
+                summary="Publication history and revision details for this specification.">
+                <thead>
+                  <tr><th>Version No.</th><th>Release Date</th><th>Comments</th></tr>
+                </thead>
+                  <tbody>
+                      <tr>
+                          <td>Candidate Final Public 1.0</td>
+                          <td>October 7, 2020</td>
+                          <td></td>
+                      </tr>
+                      <tr>
+                          <td>Base Document 1.0</td>
+                          <td>April 12th, 2018</td>
+                          <td>Initial release.</td>
+                      </tr>
+                  </tbody>
+              </table>
+           </section>
+        </section>   
 </body>
 
 </html>

--- a/ob_v2p0/extensions/issuerAccreditationExtension/index.html
+++ b/ob_v2p0/extensions/issuerAccreditationExtension/index.html
@@ -8,7 +8,7 @@
       specTitle: "Open Badges Issuer Accreditation Extension",
       shortName: "ob-accred",
       specStatus: "IMS Candidate Final Public",
-      specDate: "April 12th, 2018",
+      specDate: "October 7th, 2020",
       specVersion: "1.0",
       specNature: "normative",
       specType: "spec",


### PR DESCRIPTION
This update includes:
- Setting status of Assessment, IssuerAccreditation, and ExtraDescription extensions to Candidate Final Public
- Setting all URLs for IMS purl server to https
- Fixing a broken link to ExtraDescription files