### PR TITLE
Correct schema:targetFramework reference to schema:educationalFramework

### DIFF
--- a/ob_v2p0/history/2.0.md
+++ b/ob_v2p0/history/2.0.md
@@ -42,7 +42,6 @@ For full transparency, these edits can be reviewed at the [GitHub Open Badges ma
 
 Additional errata:
 * April 9th of 2020 the work group decided to require usage of PNG or SVG for all images under this specification.
+* In October 2020, the work group indicated that an error with the `targetFramework` term in the [V2 Context](https://w3id.org/openbadges/v2) should be corrected in place. This term previously referenced a non-existent `schema:targetFramework` term when the appropriate term in schema.org's vocabulary is [educationalFramework](http://schema.org/educationalFramework). An impact analysis was performed resulting in a conclusion that there would be very little effect on implementations in any role.
 
 Please note that the IMS Global version of the Open Badges specification, which contains additional formatting and layout changes, are not reflected in the master repository commit history.
-
-

--- a/ob_v2p0/v2/context.json
+++ b/ob_v2p0/v2/context.json
@@ -54,7 +54,7 @@
     "startsWith": { "@id": "http://purl.org/dqm-vocabulary/v1/dqm#startsWith" },
     "tags": { "@id": "schema:keywords" },
     "targetDescription": { "@id": "schema:targetDescription" },
-    "targetFramework": { "@id": "schema:targetFramework" },
+    "targetFramework": { "@id": "schema:educationalFramework" },
     "targetName": { "@id": "schema:targetName" },
     "targetUrl": { "@id": "schema:targetUrl" },
     "telephone": { "@id": "schema:telephone" },


### PR DESCRIPTION
In October 2020, the work group indicated that an error with the `targetFramework` term in the [V2 Context](https://w3id.org/openbadges/v2) should be corrected in place. This term previously referenced a non-existent `schema:targetFramework` term when the appropriate term in schema.org's vocabulary is [educationalFramework](http://schema.org/educationalFramework). An impact analysis was performed resulting in a conclusion that there would be very little effect on implementations in any role.

Resolves #272 