### PR TITLE
Endorsement errata

### DIFF
--- a/ob_v2p0/examples/index.md
+++ b/ob_v2p0/examples/index.md
@@ -557,6 +557,7 @@ Here, an endorser claims to have verified the email address published in the Pro
  "type": "Endorsement",
  "id": "https://example.org/endorsement-123.json",
  "issuer": "https://example.org/issuer-5.json",
+ "issuedOn": "2016-12-31T23:59:59+00:00",
  "claim": {
    "id": "https://example.org/organization.json",
    "email": "contact@example.org",
@@ -574,6 +575,7 @@ Another prominent use of Endorsements is to provide a comment expressing approva
  "type": "Endorsement",
  "id": "https://example.org/endorsement-124.json",
  "issuer": "https://example.org/issuer-5.json",
+ "issuedOn": "2016-12-31T23:59:59+00:00",
  "claim": {
    "id": "https://example.org/robotics-badge.json",
    "endorsementComment": "This badge and its associated learning material are great examples of beginning robotics education."
@@ -591,6 +593,7 @@ The same method could be used to support a single recipient's achievement throug
  "type": "Endorsement",
  "id": "https://example.org/endorsement-125.json",
  "issuer": "https://example.org/issuer-5.json",
+ "issuedOn": "2016-12-31T23:59:59+00:00",
  "claim": {
    "id": "https://example.org/beths-robotics-badge.json",
    "endorsementComment": "This student built a great robot.",

--- a/ob_v2p0/history/2.0.md
+++ b/ob_v2p0/history/2.0.md
@@ -43,5 +43,6 @@ For full transparency, these edits can be reviewed at the [GitHub Open Badges ma
 Additional errata:
 * April 9th of 2020 the work group decided to require usage of PNG or SVG for all images under this specification.
 * In October 2020, the work group indicated that an error with the `targetFramework` term in the [V2 Context](https://w3id.org/openbadges/v2) should be corrected in place. This term previously referenced a non-existent `schema:targetFramework` term when the appropriate term in schema.org's vocabulary is [educationalFramework](http://schema.org/educationalFramework). An impact analysis was performed resulting in a conclusion that there would be very little effect on implementations in any role.
+* February 11th of 2021 the work group updated the Endorsement examples to include the required issuedOn property for completeness.
 
 Please note that the IMS Global version of the Open Badges specification, which contains additional formatting and layout changes, are not reflected in the master repository commit history.

--- a/ob_v2p0/index.md
+++ b/ob_v2p0/index.md
@@ -596,6 +596,7 @@ Endorsements use the `claim` property to identify another entity by its `id` and
  "type": "Endorsement",
  "id": "https://example.org/assertions/123",
  "issuer": "https://example.org/issuer",
+ "issuedOn": "2016-12-31T23:59:59+00:00",
  "claim": {
    "id": "https://otherissuer.example/1",
    "email": "contact@otherissuer.example",


### PR DESCRIPTION
Addresses issue #218 and adds the `issuedOn` field to all Endorsement examples