### PR TITLE
Clarify the requirements for validatesType

### DIFF
--- a/ob_v2p0/history/2.0.md
+++ b/ob_v2p0/history/2.0.md
@@ -43,5 +43,6 @@ For full transparency, these edits can be reviewed at the [GitHub Open Badges ma
 Additional errata:
 * April 9th of 2020 the work group decided to require usage of PNG or SVG for all images under this specification.
 * In October 2020, the work group indicated that an error with the `targetFramework` term in the [V2 Context](https://w3id.org/openbadges/v2) should be corrected in place. This term previously referenced a non-existent `schema:targetFramework` term when the appropriate term in schema.org's vocabulary is [educationalFramework](http://schema.org/educationalFramework). An impact analysis was performed resulting in a conclusion that there would be very little effect on implementations in any role.
+* In February 2021, the description of `validatesType` was improved to indicate how exact matching is handled.
 
 Please note that the IMS Global version of the Open Badges specification, which contains additional formatting and layout changes, are not reflected in the master repository commit history.

--- a/ob_v2p0/index.md
+++ b/ob_v2p0/index.md
@@ -542,12 +542,13 @@ For example, this portion of the current Open Badges context links to a validato
 
 Validators using the TypeValidation method match the schema indicated by the validator's `validationSchema` property against a JSON badge object document or portion of such a document that matches the validator's `validatesType` JSON-LD `type`.
 
+It is important that the value of the `validatesType` property be a valid JSON-LD type (an IRI), as that IRI appears when compacted into the Open Badges context, because validation matches this type value here against compacted values as they appear in an extension implementation. In order to correctly identify the extension within the badge object that includes it, an exact match here is expected.
 <div class="table-wrapper">
 
 Property | Expected Type | Description/expected value
 --------|------------|-----------
 **type** | string/compact IRI ([Multiple values allowed](#array)) | `TypeValidation`.
-**validatesType** | string/compact IRI | Valid JSON-LD type for a badge component, such as `Assertion`, `extensions:ApplyLink`, or `https://w3id.org/openbadges/extensions#ApplyLink`. Compact forms preferred.
+**validatesType** | string/compact IRI | JSON-LD type as it appears compacted into the Open Badges context.
 **validationSchema** | URL | Location of a hosted JSON-schema.
 
 </div>


### PR DESCRIPTION
Implementers need to know that an exact match of a specific format of the IRI is required to pass current validation for the property `validatesType` as it is used in extensions.

Resolves #180 