### PR TITLE
Fix missing substring on endpoint labelling

### DIFF
--- a/ob_v2p1/ob-spec-v2p1.html
+++ b/ob_v2p1/ob-spec-v2p1.html
@@ -668,7 +668,7 @@ grant_type=authorization_code
   "badgeConnectAPI": [{
     "name": "A Badge Host",
     "image": "https://badgehost.example.com/logo.png",
-    "apiBase": "https://badgehost.example.com/api/obc/v1",
+    "apiBase": "https://badgehost.example.com/api/ims/ob/v2p1",
     "version": "v1p0",
     "termsOfServiceUrl": "https://badgehost.example.com/terms",
     "privacyPolicyUrl": "https://badgehost.example.com/privacy",
@@ -713,8 +713,9 @@ grant_type=authorization_code
           <tr>
             <td><code>apiBase</code></td>
             <td>Yes</td>
-            <td>Fully qualified URL that will be concatenated with the API endpoints. It SHOULD NOT have a trailing
-              slash "/". <br />
+            <td>Fully qualified URL that will be concatenated with the API endpoints. It must end with the path
+              fragment "/ims/ob/v2p1". It SHOULD NOT have a trailing slash "/".
+              <br />
               E.g. <code>apiBase + "/assertions"</code>
             </td>
           </tr>


### PR DESCRIPTION
Fixes #307

Because the problem is that something is missing, it is hard to be confident that I found all occurrences. Please let me know if the substring "ims/ob/v2p1" should be added anywhere else.

Note: This preview ONLY includes the changes in this PR:

[Open Badges Specification 2.1 IMS Candidate Final Public.pdf](https://github.com/IMSGlobal/openbadges-specification/files/7401544/Open.Badges.Specification.2.1.IMS.Candidate.Final.Public.pdf)

