### PR TITLE
Skill assertions

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -144,8 +144,9 @@ Package Credentials DataModel
 
     Class Result Unordered false []                                 "Describes a result that was achieved."
         Property achievedLevel URI 0..1                             "If the result represents an achieved rubric criterion level (e.g. Mastered), the value is the `id` of the RubricCriterionLevel in linked ResultDescription."
-        Property alignments Alignment 0..*                          "q:Should result alignments be removed in CLR20/OB30?"
-        Property resultDescription URI 1                            "An achievement can have many result descriptions describing possible results. The value of `resultDescription` is the `id` of the result description linked to this result. The linked result description must be in the achievement that is being asserted."
+        Property alignments Alignment 0..*                          "q:Should Result alignments be removed in CLR20/OB30?"
+        Property resultDescription URI 0..1                         "An achievement can have many result descriptions describing possible results. The value of `resultDescription` is the `id` of the result description linked to this result. The linked result description must be in the achievement that is being asserted."
+        Property skill URI 0..1                                     "The unique URI of the skill being claimed. The URI can identify any RSD (Rich Skill Descriptor). If a skill is identified, the containing assertion is a 'Skill Assertion' that claims the subject has the defined skill."
         Property status ResultStatusType 0..1                       "The status of the achievement. Required if `resultType` of the linked ResultDescription is Status."
         Property value String 0..1                                  "A string representing the result of the performance, or demonstration, of the achievement. For example, 'A' if the recipient received an A grade in class."
         Property extensions Namespace 0..1

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -13,7 +13,7 @@ Package OpenBadges DataModel
 
 // Pull in common credential models (this will be converted to Includes when credential models are finalized and made part of the CDM)
 
-Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/develop/ob_v3p0/common_credentials.lines
+Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/skill-assertion/ob_v3p0/common_credentials.lines
 
 Package SharedApi DataModel
 


### PR DESCRIPTION
This PR will add a new `skill` property to the `Result` class to enable "[Skill Assertions](https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#skill-assertions)".

Note this also makes `resultDescription` optional.