### PR TITLE
First sync of data models with CDM

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -99,6 +99,10 @@ Package Credentials DataModel
         Property artifacts Artifact 0..*                            "Artifacts that are part of the evidence."
         Mixin Extensions
 
+    Include GeoCoordinates
+    
+    Include IdentifierEntry
+
     Class IdentityObject Unordered false []                         "A collection of information about the recipient of an achievement."
         Property identityHash String 1                              "Either the IdentityHash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information where there is an expectation of privacy, it is strongly recommended that an IdentityHash be used."
         Property type IRI 1                                         "The IRI of the property by which the recipient of the achievement is identified. This value should be an IRI mapped in the present context. For example, `email` maps to `http://schema.org/email` and indicates that the identity of the IdentityObject will represent a value of a Profile's `email` property. See [[#profile-identifier-properties]]."
@@ -220,6 +224,8 @@ Package Credentials DataModel
         Property CFRubricCriterionLevel Term 1                      "An alignment to a CASE Framework Rubric Criterion Level."
         Property CTDL Term 1                                        "An alignment to a Credential Engine Item."
 
+    Include IdentifierTypeEnum
+
     Class ResultType EnumExt false []                               "The type of result. This is an extensible enumerated vocabulary. Extending the vocabulary makes use of a naming convention."
         Property GradePointAverage Term 1                           "The result is a grade point average."
         Property LetterGrade Term 1                                 "The result is a letter grade."
@@ -242,14 +248,11 @@ Package Credentials DataModel
         Property OnHold Term 1                                      "The learner has completed the activity described by the achievement, but successful completion has not been awarded, typically for administrative reasons."
         Property Withdrew Term 1                                    "The learner withdrew from the activity described by the achievement before completion."
 
-    Includes [CountryCode, GeoCoordinates]
-    Includes [Email, EmailAddress]
-    Includes [Phone, PhoneNumber]
-    Includes [UUID]
-    Includes [OtherIdentifiers, IdentifierEntry, AnyIdentifier, IdentifierType, Identifier]
-    Include IdentifierTypeEnum
+    Includes [Email]
+    Includes [Phone]
+    Includes [OtherIdentifiers, AnyIdentifier, IdentifierType]
     Include PersonNameParts
-    Includes [Extensions, BaseTerm]
+    Includes [Extensions]
 
 
 Package ProofModels DataModel                                       "Data models shared by all proof formats."
@@ -311,7 +314,7 @@ Package SharedOAuth DataModel
 // Derived Types
 
 Package DerivedTypes DataModel
-    Includes [IRI, Term, URI, URL]
+    Includes [BaseTerm, CountryCode, EmailAddress, Identifier, IRI, PhoneNumber, Term, URI, URL, UUID]
     Class CompactJws DerivedType false [String]                     "A `String` in Compact JWS format [[RFC7515]]."
     Class IdentityHash DerivedType false [String]                   "A hash string containing an algorithm identifier and a resulting hash of an identifier, separated by a dollar sign ("$") and the algorithm used to generate the hash. The only supported algorithms are MD5 [[RFC1321]] and SHA-256 [[FIPS-180-4]], identified by the strings md5 and sha256 respectively. Resulting hash for each of these algorithms MUST be expressed in hexadecimal using uppercase (A-F, 0-9) or lowercase character (a-f, 0-9) sets. For example: sha256$7a1a1b3f7d40552e4299180e346e3add12bf9a751a43d9c4ca4518febc2c60c6 represents the result of calculating a SHA-256 hash on the string "mayze"."
     Class Markdown DerivedType false [String]                       "A `String` that may contain Markdown."

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -224,7 +224,7 @@ Package Credentials DataModel
         Property CFRubricCriterionLevel Term 1                      "An alignment to a CASE Framework Rubric Criterion Level."
         Property CTDL Term 1                                        "An alignment to a Credential Engine Item."
 
-    Include IdentifierTypeEnum
+    Include IdentifierTypeEnum                                      // From CDM
 
     Class ResultType EnumExt false []                               "The type of result. This is an extensible enumerated vocabulary. Extending the vocabulary makes use of a naming convention."
         Property GradePointAverage Term 1                           "The result is a grade point average."

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -176,7 +176,7 @@ Package Credentials DataModel
     // Enumerations
 
     Class AchievementType EnumExt false []                          "The type of achievement, for example "Award" or "Certification". This is an extensible enumerated vocabulary. Extending the vocabulary makes use of a naming convention."
-        Property Achievement Term 1                                 "Represents a generic achievement."
+        Property Achievement BaseTerm 1                             "Represents a generic achievement."
         Property Assessment Term 1                                  "Represents the result of a skill, competency, or outcome-based summative assessment."
         Property Assignment Term 1                                  "Represents the result of a curricular, or co-curricular assignment or exam."
         Property Award Term 1                                       "Represents an award."
@@ -207,7 +207,7 @@ Package Credentials DataModel
         Property PerformanceLevel Term 1                            "The result is a performance level."
         Property PredictedScore Term 1                              "The result is a predicted score."
         Property RawScore Term 1                                    "The result is a raw score."
-        Property Result Term 1                                      "A generic result."
+        Property Result BaseTerm 1                                  "A generic result."
         Property RubricCriterion Term 1                             "The result is from a rubric criterion."
         Property RubricCriterionLevel Term 1                        "The result is a rubric criterion level."
         Property RubricScore Term 1                                 "The result represents a rubric score with both a name and a numeric value."

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -2,6 +2,8 @@
 
 Package Credentials DataModel
 
+    Includes [Address]
+
     Class AssertionCredential Unordered false [VerifiableCredential] "AssertionCredentials are representations of an awarded achievement, used to share information about a achievement belonging to one earner. Maps to a Verifiable Credential as defined in the [[VC-DATA-MODEL]]."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value "https://www.w3.org/2018/credentials/v1", and the second item is a URI with the value "https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld"."
         Property id URI 1                                           "Unambiguous reference to the assertion. Required so it can be the subject of an endorsement."
@@ -44,14 +46,14 @@ Package Credentials DataModel
         Property tags String 0..*                                   "Tags that describes the type of achievement."
         Property extensions Namespace 0..1
 
-    Class Address Unordered false []                                "The physical address of a person or organization."
-        Property addressCountry String 0..1                         "The country. For example, USA. You can also provide the two-letter [[ISO3166-1]] alpha-2 country code."
-        Property addressLocality String 0..1                        "The locality. For example, Mountain View."
-        Property addressRegion String 0..1                          "The region. For example, CA."
-        Property postalCode String 0..1                             "The postal code. For example, 94043."
-        Property postOfficeBoxNumber String 0..1                    "The post office box number for PO box addresses."
-        Property streetAddress String 0..1                          "The street address. For example, 1600 Amphitheatre Pkwy."
-        Property extensions Namespace 0..1
+    // Class Address Unordered false []                                "The physical address of a person or organization."
+    //    Property addressCountry String 0..1                         "The country. For example, USA. You can also provide the two-letter [[ISO3166-1]] alpha-2 country code."
+    //    Property addressLocality String 0..1                        "The locality. For example, Mountain View."
+    //    Property addressRegion String 0..1                          "The region. For example, CA."
+    //    Property postalCode String 0..1                             "The postal code. For example, 94043."
+    //    Property postOfficeBoxNumber String 0..1                    "The post office box number for PO box addresses."
+    //    Property streetAddress String 0..1                          "The street address. For example, 1600 Amphitheatre Pkwy."
+    //    Property extensions Namespace 0..1
 
     Class Alignment Unordered false []                              "Describes an alignment between an achievement and a node in an educational framework."
         Property targetCode String 0..1                             "If applicable, a locally unique string identifier that identifies the alignment target within its framework and/or targetUrl."
@@ -289,7 +291,6 @@ Package ProofModels DataModel                                       "Data models
 Package SharedApi DataModel
 
     Includes [Imsx_StatusInfo, Imsx_CodeMajor, Imsx_Severity, Imsx_CodeMinor, Imsx_CodeMinorField, Imsx_CodeMinorFieldValue]
-    Includes [PrimaryAddress]
 
 Package SharedOAuth DataModel
 

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -129,7 +129,7 @@ Package Credentials DataModel
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         Property email String 0..1                                  "Contact address for the individual or organization."
         // Property address Address 0..1                               "An address for the individual or organization."
-        Mixin PrimaryAddress
+        // Mixin PrimaryAddress
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         Property birthDate Date 0..1                                "Birthdate of the person."
         Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -15,7 +15,7 @@ Package Credentials DataModel
         Property expirationDate DateTime 0..1                       "If the achievement assertion has some notion of expiry, this indicates a timestamp when a credential should no longer be considered valid. After this time, the achievement assertion should be considered expired."
         Property proof Proof 0..*                                   "One or more cryptographic proofs that can be used to detect tampering and verify the authorship of the achievement assertion."
         Property credentialStatus CredentialStatus 0..1             "Provides information about the current status of a verifiable credential, such as whether it is suspended or revoked."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class AssertionSubject Unordered false [CredentialSubject]      "A collection of information about the recipient of an achievement. Maps to Credential Subject in [[VC-DATA-MODEL]]."
         Property id URI 0..1                                        "An identifier for the Credential Subject. Either `id` or `recipient` or both is required."
@@ -23,7 +23,7 @@ Package Credentials DataModel
         Property achievement Achievement 0..1                       "The achievement being awarded."
         Property evidence Evidence 0..*                             "A description of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible."
         Property results Result 0..*                                "The set of results being asserted."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class Achievement Unordered false []                            "A collection of information about the accomplishment recognized by the Assertion. Many assertions may be created corresponding to one Achievement."
         Property id URI 1                                           "Unique URI for the Achievement. Required so the achievement can be the subject of an endorsement."
@@ -35,23 +35,14 @@ Package Credentials DataModel
         Property description String 0..1                            "A short description of the achievement."
         Property fieldOfStudy String 0..1                           "Category, subject, area of study, discipline, or general branch of knowledge. Examples include Business, Education, Psychology, and Technology."
         Property humanCode String 0..1                              "The code, generally human readable, associated with an achievement."
-        Property identifiers SystemIdentifier 0..*                  "A set of System Identifiers that represent other identifiers for this Achievement."
+        Mixin OtherIdentifiers
         Property image Image 0..1                                   "An image of the achievement. This must be a PNG or SVG image."
         Property level String 0..1                                  "Text that describes the level of achievement apart from how the achievement was performed or demonstrated. Examples would include "Level 1", "Level 2", "Level 3", or "Bachelors", "Masters", "Doctoral"."
         Property name String 1                                      "The name of the achievement."
         Property resultDescriptions ResultDescription 0..*          "The set of result descriptions that may be asserted as results with this achievement."
         Property specialization String 0..1                         "Name given to the focus, concentration, or specific area of study defined in the achievement. Examples include Entrepreneurship, Technical Communication, and Finance."
         Property tags String 0..*                                   "Tags that describes the type of achievement."
-        Property extensions Namespace 0..1
-
-    // Class Address Unordered false []                                "The physical address of a person or organization."
-    //    Property addressCountry String 0..1                         "The country. For example, USA. You can also provide the two-letter [[ISO3166-1]] alpha-2 country code."
-    //    Property addressLocality String 0..1                        "The locality. For example, Mountain View."
-    //    Property addressRegion String 0..1                          "The region. For example, CA."
-    //    Property postalCode String 0..1                             "The postal code. For example, 94043."
-    //    Property postOfficeBoxNumber String 0..1                    "The post office box number for PO box addresses."
-    //    Property streetAddress String 0..1                          "The street address. For example, 1600 Amphitheatre Pkwy."
-    //    Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class Alignment Unordered false []                              "Describes an alignment between an achievement and a node in an educational framework."
         Property targetCode String 0..1                             "If applicable, a locally unique string identifier that identifies the alignment target within its framework and/or targetUrl."
@@ -60,13 +51,13 @@ Package Credentials DataModel
         Property targetFramework String 0..1                        "Name of the framework the alignment target."
         Property targetType AlignmentTargetType 0..1                "The type of the alignment target node."
         Property targetUrl URL 1                                    "URL linking to the official description of the alignment target, for example an individual standard within an educational framework."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class Artifact Unordered false []                               "An artifact that is part of an evidence object."
         Property description String 0..1                            "A description of the artifact."
         Property name String 0..1                                   "The name of the artifact."
         Property url URI 0..1                                       "URI for the artifact which may be a Data URI ([[RFC2397]]) or the URL where the artifact can be found."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class CredentialSchema Unordered false []                       "Identify the type and location of a data schema."
         Property id URI 1                                           "The value MUST be a URI identifying the schema file. One instance of `CredentialSchema` MUST have an `id` that is the URL of the JSON Schema for this credential defined by this specification."
@@ -75,12 +66,12 @@ Package Credentials DataModel
     Class CredentialStatus Unordered false []                       "The information in CredentialStatus is used to discover information about the current status of a verifiable credential, such as whether it is suspended or revoked."
         Property id URI 1
         Property type URI 1                                         "Expresses the credential status type (also referred to as the credential status method). It is expected that the value will provide enough information to determine the current status of the credential. For example, the object could contain a link to an external document noting whether or not the credential is suspended or revoked."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class Criteria Unordered false []                               "Descriptive metadata about the achievements necessary to be recognized with an assertion of a particular achievement. This data is added to the Achievement class so that it may be rendered when the achievement assertion is displayed, instead of simply a link to human-readable criteria external to the achievement. Embedding criteria allows either enhancement of an external criteria page or increased portability and ease of use by allowing issuers to skip hosting the formerly-required external criteria page altogether. Criteria is used to allow would-be recipients to learn what is required of them to be recognized with an assertion of a particular achievement. It is also used after the assertion is awarded to a recipient to let those inspecting earned achievements know the general requirements that the recipients met in order to earn it."
         Property id URI 0..1                                        "The URI of a webpage that describes in a human-readable format the criteria for the achievement."
         Property narrative Markdown 0..1                            "A narrative of what is needed to earn the achievement. Markdown is allowed."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class EndorsementCredential Unordered false [VerifiableCredential] "A verifiable credential that asserts a claim about an entity."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value "https://www.w3.org/2018/credentials/v1", and the second item is a URI with the value "https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld"."
@@ -94,7 +85,7 @@ Package Credentials DataModel
     Class EndorsementSubject Unordered false [CredentialSubject]    "A collection of information about the subject of the endorsement."
         Property id URI 1                                           "The identifier of the individual, entity, organization, assertion, or achievement that is endorsed."
         Property endorsementComment Markdown 0..1                   "Allows endorsers to make a simple claim in writing about the entity."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class Evidence Unordered false []                               "Descriptive metadata about evidence related to the achievement assertion. Each instance of the evidence class present in an assertion corresponds to one entity, though a single entry can describe a set of items collectively. There may be multiple evidence entries referenced from an assertion. The narrative property is also in scope of the assertion class to provide an overall description of the achievement related to the assertion in rich text. It is used here to provide a narrative of achievement of the specific entity described. If both the description and narrative properties are present, displayers can assume the narrative value goes into more detail and is not simply a recapitulation of description."
         Property id URI 0..1                                        "The URL of a webpage presenting evidence of achievement or the evidence encoded as a Data URI."
@@ -104,7 +95,7 @@ Package Credentials DataModel
         Property genre String 0..1                                  "A string that describes the type of evidence. For example, Poetry, Prose, Film."
         Property audience String 0..1                               "A description of the intended audience for a piece of evidence."
         Property artifacts Artifact 0..*                            "Artifacts that are part of the evidence."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class IdentityObject Unordered false []                         "A collection of information about the recipient of an achievement."
         Property identityHash String 1                              "Either the IdentityHash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information where there is an expectation of privacy, it is strongly recommended that an IdentityHash be used."
@@ -116,7 +107,7 @@ Package Credentials DataModel
         Property id URI 1                                           "The URI or Data URI of the image."
         Property caption String 0..1                                "The caption for the image."
         Property author Profile 0..1                                "The author of the image, if desired."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class Proof Unordered false []                                  "A JSON-LD Linked Data proof. [[DATA-INTEGRITY]]"
         Property type String 1                                      "Signature suite used to produce proof."
@@ -128,7 +119,7 @@ Package Credentials DataModel
         Property proofPurpose String 1                              "The purpose of the proof to be used with `verificationMethod`. MUST be "assertionMethod"."
         Property proofValue String 1                                "Value of the proof."
         Property verificationMethod URI 1                           "The identifier of the public key that can verify the signature"
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class Result Unordered false []                                 "Describes a result that was achieved."
         Property achievedLevel URI 0..1                             "If the result represents an achieved rubric criterion level (e.g. Mastered), the value is the `id` of the RubricCriterionLevel in linked ResultDescription."
@@ -136,7 +127,7 @@ Package Credentials DataModel
         Property resultDescription URI 0..1                         "An achievement can have many result descriptions describing possible results. The value of `resultDescription` is the `id` of the result description linked to this result. The linked result description must be in the achievement that is being asserted."
         Property status ResultStatusType 0..1                       "The status of the achievement. Required if `resultType` of the linked ResultDescription is Status."
         Property value String 0..1                                  "A string representing the result of the performance, or demonstration, of the achievement. For example, "A" if the recipient received an A grade in class."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class ResultDescription Unordered false []                      "Describes a possible achievement result."
         Property id URI 1                                           "The unique URI for this result description. Required so a result can link to this result description."
@@ -149,7 +140,7 @@ Package Credentials DataModel
         Property rubricCriterionLevels RubricCriterionLevel 0..*    "An ordered array of rubric criterion levels that may be asserted in the linked result. The levels should be ordered from low to high as determined by the achievement creator."
         Property valueMax String 0..1                               "The maximum possible `value` that may be asserted in a linked result."
         Property valueMin String 0..1                               "The minimum possible `value` that may be asserted in a linked result."
-        Property extensions Namespace 0..1
+        Mixin Extensions
 
     Class RubricCriterionLevel Unordered false []                   "Describes a rubric criterion level."
         Property id URI 1                                           "The unique URI for this rubric criterion level. Required so a result can link to this rubric criterion level."
@@ -158,11 +149,7 @@ Package Credentials DataModel
         Property level String 0..1                                  "The rubric performance lvel in terms of success."
         Property name String 1                                      "The name of the rubric criterion level."
         Property points String 0..1                                 "The points associated with this rubric criterion level."
-        Property extensions Namespace 0..1
-
-    Class SystemIdentifier Unordered false []                       "A system identifier represents a single, system-local identifier."
-        Property identifier String 1                                "Opaque string representing the system identifier value."
-        Property identifierType IdentifierType 1                    "The identifier type. This is an extensible enumerated vocabulary. Extending the vocabulary makes use of a naming convention. For example, the NCES School ID might be "ext:NcesSchoolId". Extended vocabulary terms must start with "ext:" followed by any valid JSON string value."
+        Mixin Extensions
 
     Class VerifiableCredential Unordered false []                   "A Verifiable Credential as defined in the [[VC-DATA-MODEL]]."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value "https://www.w3.org/2018/credentials/v1"."
@@ -171,7 +158,7 @@ Package Credentials DataModel
         Property issuer Profile 1                                   "A description of the individual, entity, or organization that issued the credential."
         Property issuanceDate DateTime 1                            "Timestamp of when the credential was awarded."
         Property credentialSubject CredentialSubject 1              "The subject of the credential."
-        Property extensions Namespace 0..*
+        Mixin Extensions
 
     Class VerifiablePresentation Unordered false []                 "A Verifiable Presentation as defined in the [[VC-DATA-MODEL]]."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value `https://www.w3.org/2018/credentials/v1`."
@@ -180,11 +167,11 @@ Package Credentials DataModel
         Property verifiableCredential VerifiableCredential 1..*     "The unordered set of verifiable credentials being presented."
         Property holder URI 0..1                                    "If present, the value of the `holder` is expected to be a URI for the entity that is generating the presentation."
         Property proof Proof 0..*                                   "If present, the value of the `proof` property ensures that the presentation is verifiable."
-        Property extensions Namespace 0..* 
+        Mixin Extensions 
 
     Class CredentialSubject Unordered false []                      "Claims about the credential subject. Maps to Credential Subject as defined in the [[VC-DATA-MODEL]]."
         Property id URI 0..1                                        "The identity of the credential subject."
-        Property extensions Namespace 0..* 
+        Mixin Extensions
 
     // Enumerations
 
@@ -212,10 +199,6 @@ Package Credentials DataModel
         Property CFRubricCriterion Term 1                           "An alignment to a CASE Framework Rubric Criterion."
         Property CFRubricCriterionLevel Term 1                      "An alignment to a CASE Framework Rubric Criterion Level."
         Property CTDL Term 1                                        "An alignment to a Credential Engine Item."
-
-    Class IdentifierType EnumExt false []                           "The type of identifier. This is an extensible enumerated vocabulary. Extending the vocabulary makes use of a naming convention."
-        Property LisSourcedId Term 1                                "The IMS LIS sourcedId for the achievement represented by the Achievement instance or the IMS LIS sourcedId for the person or organization represented by the Profile instance."
-        Property OneRosterSourcedId Term 1                          "The IMS OneRoster sourcedId for the achievement represented by the Achievement instance or the IMS OneRoster sourcedId for the person or organization represented by the Profile instance."
 
     Class ResultType EnumExt false []                               "The type of result. This is an extensible enumerated vocabulary. Extending the vocabulary makes use of a naming convention."
         Property GradePointAverage Term 1                           "The result is a grade point average."
@@ -248,7 +231,7 @@ Package ProofModels DataModel                                       "Data models
         Property verifiableCredential CompactJws 1..*               "The set of credentials being presented in Compact JWS format."
         Property holder URI 0..1                                    "If present, the value of the `holder` is expected to be a URI for the entity that is generating the presentation."
         Property proof Proof 0..*                                   "If present, the value of the `proof` property has information about the Linked Data Proofs embedded in the presentation."
-        Property extensions Namespace 0..* 
+        Mixin Extensions 
 
     Class JWK Unordered false []                                    "A JSON Web Key (JWK) formatted according to [[RFC7517]]."
         Property kty String 1                                       "The `kty` (key type) parameter identifies the cryptographic algorithm family used with the key, such as `RSA` or `EC`."
@@ -260,7 +243,7 @@ Package ProofModels DataModel                                       "Data models
         Property x5c String 0..*                                    "The `x5c` (X.509 certificate chain) parameter contains a chain of one or more PKIX certificates [[RFC5280]]."
         Property x5t String 0..1                                    "The `x5t` (X.509 certificate SHA-1 thumbprint) parameter is a base64url-encoded SHA-1 thumbprint (a.k.a. digest) of the DER encoding of an X.509 certificate [[RFC5280]]."
         Property x5t_S256 String 0..1                               "The `x5t#S256` (X.509 certificate SHA-256 thumbprint) parameter is a base64url-encoded SHA-256 thumbprint (a.k.a. digest) of the DER encoding of an X.509 certificate [[RFC5280]]."
-        Property extensions Namespace 0..* 
+        Mixin Extensions
 
     Class JWKS Unordered false []                                   "A JWK Set (JWKS) formatted according to [[RFC7517]]."
         Property keys JWK 1..*                                      "A JWK Set is a JSON object that represents a set of JWKs."

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -248,13 +248,6 @@ Package Credentials DataModel
         Property OnHold Term 1                                      "The learner has completed the activity described by the achievement, but successful completion has not been awarded, typically for administrative reasons."
         Property Withdrew Term 1                                    "The learner withdrew from the activity described by the achievement before completion."
 
-    Includes [Email]
-    Includes [Phone]
-    Includes [OtherIdentifiers, AnyIdentifier, IdentifierType]
-    Include PersonNameParts
-    Includes [Extensions]
-
-
 Package ProofModels DataModel                                       "Data models shared by all proof formats."
 
     Class PresentationJwsPayload Unordered false []                 "Represents a set of credentials expressed to conform with the `vp` claim in JSON Web Token Proof Format [[VC-DATA-MODEL]]. Nested credentials are represented as Compact JWS strings."
@@ -329,3 +322,8 @@ Package PrimitiveTypes DataModel
     Class NumericDate PrimitiveType false []                        "A number representing the number of seconds from from 1970-01-01T00:00:00Z UTC until the specified UTC data/time, ignoring leap seconds."
     Class Namespace PrimitiveType false []                          "A namespace data type for defining data from a context other than that as the default for the data model. This is used for importing other data models."
     Class String PrimitiveType false []                             "Character strings"
+
+// Mixins
+
+Package Mixins DataModel
+    Includes [AnyIdentifier, Email, Extensions, IdentifierType, OtherIdentifiers, PersonNameParts, Phone]

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -2,7 +2,7 @@
 
 Package Credentials DataModel
 
-    Include Address
+    Include Address                                                 // From CDM
 
     Class AssertionCredential Unordered false [VerifiableCredential] "AssertionCredentials are representations of an awarded achievement, used to share information about a achievement belonging to one earner. Maps to a Verifiable Credential as defined in the [[VC-DATA-MODEL]]."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value "https://www.w3.org/2018/credentials/v1", and the second item is a URI with the value "https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld"."
@@ -37,7 +37,7 @@ Package Credentials DataModel
         Property description String 0..1                            "A short description of the achievement."
         Property fieldOfStudy String 0..1                           "Category, subject, area of study, discipline, or general branch of knowledge. Examples include Business, Education, Psychology, and Technology."
         Property humanCode String 0..1                              "The code, generally human readable, associated with an achievement."
-        Mixin OtherIdentifiers
+        Mixin OtherIdentifiers                                      // From CDM
         Property image Image 0..1                                   "An image of the achievement. This must be a PNG or SVG image."
         Property level String 0..1                                  "Text that describes the level of achievement apart from how the achievement was performed or demonstrated. Examples would include "Level 1", "Level 2", "Level 3", or "Bachelors", "Masters", "Doctoral"."
         Property name String 1                                      "The name of the achievement."
@@ -99,9 +99,9 @@ Package Credentials DataModel
         Property artifacts Artifact 0..*                            "Artifacts that are part of the evidence."
         Mixin Extensions
 
-    Include GeoCoordinates
+    Include GeoCoordinates                                          // From CDM
     
-    Include IdentifierEntry
+    Include IdentifierEntry                                         // From CDM
 
     Class IdentityObject Unordered false []                         "A collection of information about the recipient of an achievement."
         Property identityHash String 1                              "Either the IdentityHash of the identity or the plaintext value. If it's possible that the plaintext transmission and storage of the identity value would leak personally identifiable information where there is an expectation of privacy, it is strongly recommended that an IdentityHash be used."
@@ -119,16 +119,16 @@ Package Credentials DataModel
         Property id URI 1                                           "Unique URI for the entity described by this profile. Required so the entity can be the subject of an endorsement."
         Property name String 0..1                                   "The name of the entity."
         Property url URI 0..1                                       "The homepage or social media profile of the entity. Should be a URL/URI Accessible via HTTP."
-        Mixin Phone
+        Mixin Phone                                                 // From CDM
         Property description String 0..1                            "A short description of the entity."
         Property image Image 0..1                                   "An image representing the entity. This must be a PNG or SVG image."
-        Mixin Email
+        Mixin Email                                                 // From CDM
         Property address Address 0..1                               "An address for the individual or organization."
-        Mixin OtherIdentifiers
+        Mixin OtherIdentifiers                                      // From CDM
         Property official String 0..1                               "If the entity is an organization, `official` is the name of an authorized official of the organization."
         Property parentOrg Profile 0..1                             "The parent organization of the entity."
         Property sourcedId UUID 0..1                                "The sourcedId of the profile. This is the interoperability identifier that systems will refer to when making API calls, or when needing to identify an object. Systems SHOULD be able to map whichever local ids (e.g. database key fields) they use to sourcedId. The sourcedId of an object MUST be an anonymized or pseudonymized identifier of an entity and as such will not contain Personally Identifiable Information (PII) or Personal Data (PD)."
-        Mixin PersonNameParts
+        Mixin PersonNameParts                                       // From CDM
         Property dateOfBirth Date 0..1                              ""Birthdate of the person."
         Property sisSourcedId String 0..1                           "An institution's student identifier for the person. This is frequently issued through a Student Information System."
         Mixin Extensions

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -2,8 +2,6 @@
 
 Package Credentials DataModel
 
-    Includes [Address]
-
     Class AssertionCredential Unordered false [VerifiableCredential] "AssertionCredentials are representations of an awarded achievement, used to share information about a achievement belonging to one earner. Maps to a Verifiable Credential as defined in the [[VC-DATA-MODEL]]."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value "https://www.w3.org/2018/credentials/v1", and the second item is a URI with the value "https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld"."
         Property id URI 1                                           "Unambiguous reference to the assertion. Required so it can be the subject of an endorsement."
@@ -118,27 +116,6 @@ Package Credentials DataModel
         Property id URI 1                                           "The URI or Data URI of the image."
         Property caption String 0..1                                "The caption for the image."
         Property author Profile 0..1                                "The author of the image, if desired."
-        Property extensions Namespace 0..1
-
-    Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
-        Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
-        Property name String 0..1                                   "The name of the person organization."
-        Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
-        Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
-        Property description String 0..1                            "A short description of the issuer entity or organization."
-        Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
-        Property email String 0..1                                  "Contact address for the individual or organization."
-        // Property address Address 0..1                               "An address for the individual or organization."
-        // Mixin PrimaryAddress
-        Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
-        Property birthDate Date 0..1                                "Birthdate of the person."
-        Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."
-        Property givenName String 0..1                              "Given name of a person. In the U.S., the first name of a person."
-        Property identifiers SystemIdentifier 0..*                  "A set of System Identifiers that represent other identifiers for this Profile."
-        Property official String 0..1                               "The name of the authorized official for the Issuer."
-        Property parentOrg Profile 0..1                             "The parent organization of the person or organization represented by this organization."
-        Property sourcedId String 0..1                              "The individual's or organization's unique `sourcedId` value, which is used for providing interoperability with other identity systems."
-        Property studentId String 0..1                              "An institution's student identifier for the person. This is frequently issued through a Student Information System."
         Property extensions Namespace 0..1
 
     Class Proof Unordered false []                                  "A JSON-LD Linked Data proof. [[DATA-INTEGRITY]]"

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -2,6 +2,8 @@
 
 Package Credentials DataModel
 
+    Include Address
+
     Class AssertionCredential Unordered false [VerifiableCredential] "AssertionCredentials are representations of an awarded achievement, used to share information about a achievement belonging to one earner. Maps to a Verifiable Credential as defined in the [[VC-DATA-MODEL]]."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value "https://www.w3.org/2018/credentials/v1", and the second item is a URI with the value "https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld"."
         Property id URI 1                                           "Unambiguous reference to the assertion. Required so it can be the subject of an endorsement."
@@ -107,6 +109,24 @@ Package Credentials DataModel
         Property id URI 1                                           "The URI or Data URI of the image."
         Property caption String 0..1                                "The caption for the image."
         Property author Profile 0..1                                "The author of the image, if desired."
+        Mixin Extensions
+
+    Class Profile Unordered false []                                "A profile is a collection of information that describes a person or organization (an entity). Profiles are used to identify and describe issuers, holders, and creators."
+        Property id URI 1                                           "Unique URI for the entity described by this profile. Required so the entity can be the subject of an endorsement."
+        Property name String 0..1                                   "The name of the entity."
+        Property url URI 0..1                                       "The homepage or social media profile of the entity. Should be a URL/URI Accessible via HTTP."
+        Mixin Phone
+        Property description String 0..1                            "A short description of the entity."
+        Property image Image 0..1                                   "An image representing the entity. This must be a PNG or SVG image."
+        Mixin Email
+        Property address Address 0..1                               "An address for the individual or organization."
+        Mixin OtherIdentifiers
+        Property official String 0..1                               "If the entity is an organization, `official` is the name of an authorized official of the organization."
+        Property parentOrg Profile 0..1                             "The parent organization of the entity."
+        Property sourcedId UUID 0..1                                "The sourcedId of the profile. This is the interoperability identifier that systems will refer to when making API calls, or when needing to identify an object. Systems SHOULD be able to map whichever local ids (e.g. database key fields) they use to sourcedId. The sourcedId of an object MUST be an anonymized or pseudonymized identifier of an entity and as such will not contain Personally Identifiable Information (PII) or Personal Data (PD)."
+        Mixin PersonNameParts
+        Property dateOfBirth Date 0..1                              ""Birthdate of the person."
+        Property sisSourcedId String 0..1                           "An institution's student identifier for the person. This is frequently issued through a Student Information System."
         Mixin Extensions
 
     Class Proof Unordered false []                                  "A JSON-LD Linked Data proof. [[DATA-INTEGRITY]]"
@@ -221,6 +241,16 @@ Package Credentials DataModel
         Property InProgress Term 1                                  "The learner has started progress in the activity described by the achievement."
         Property OnHold Term 1                                      "The learner has completed the activity described by the achievement, but successful completion has not been awarded, typically for administrative reasons."
         Property Withdrew Term 1                                    "The learner withdrew from the activity described by the achievement before completion."
+
+    Includes [CountryCode, GeoCoordinates]
+    Includes [Email, EmailAddress]
+    Includes [Phone, PhoneNumber]
+    Includes [UUID]
+    Includes [OtherIdentifiers, IdentifierEntry, AnyIdentifier, IdentifierType, Identifier]
+    Include IdentifierTypeEnum
+    Include PersonNameParts
+    Includes [Extensions, BaseTerm]
+
 
 Package ProofModels DataModel                                       "Data models shared by all proof formats."
 

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -289,6 +289,7 @@ Package ProofModels DataModel                                       "Data models
 Package SharedApi DataModel
 
     Includes [Imsx_StatusInfo, Imsx_CodeMajor, Imsx_Severity, Imsx_CodeMinor, Imsx_CodeMinorField, Imsx_CodeMinorFieldValue]
+    Includes [PrimaryAddress]
 
 Package SharedOAuth DataModel
 

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -118,15 +118,16 @@ Package Credentials DataModel
         Property author Profile 0..1                                "The author of the image, if desired."
         Property extensions Namespace 0..1
 
-    Class Profile Unordered false []                                "A Profile is a collection of information that describes the entity or organization using Open Badges. Issuers must be represented as Profiles, and recipients, endorsers, or other entities may also be represented using this vocabulary. Each Profile that represents an Issuer may be referenced in many BadgeClasses that it has defined. Anyone can create and host an Issuer file to start issuing Open Badges. Issuers may also serve as recipients of Open Badges, often identified within an Assertion by specific properties, like their url or contact email address."
+    Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
-        Property name String 0..1                                   "The name of the entity or organization."
+        Property name String 0..1                                   "The name of the person organization."
         Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
         Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
         Property description String 0..1                            "A short description of the issuer entity or organization."
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         Property email String 0..1                                  "Contact address for the individual or organization."
-        Property address Address 0..1                               "An address for the individual or organization."
+        // Property address Address 0..1                               "An address for the individual or organization."
+        Mixin PrimaryAddress
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         Property birthDate Date 0..1                                "Birthdate of the person."
         Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."

--- a/ob_v3p0/ob_v3p0.html
+++ b/ob_v3p0/ob_v3p0.html
@@ -15,8 +15,8 @@
   <script class="remove" src="cdm-config.js"></script>
 
   <!-- Load ajv2019 (Another JSON Schema Validator) if you want your examples validated -->
-  <script class="remove" src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.8.2/ajv2019.bundle.min.js" 
-          integrity="sha512-9CfeXrjdW9wxGntWtQ4wE0k9RD8avpYxoPEKAGu+EP87RyqXYVQjed0l872XkNtQeIyYavZeqY+jzm69pmjEDw==" 
+  <script class="remove" src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.11.0/ajv2019.bundle.min.js" 
+          integrity="sha512-C+5LzjYlC8qhPFniPXiod8efyXJ3fDRCUS87L8o8z5CGt/1LHflMozW6py7s16Z+TJy52C9teuDUq6iq2Nft7A==" 
           crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
   <script class='remove'>

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,6 +4,7 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
+    Includes [Address, AddressTypeEnum, OptionallyTypedAddress]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -6,12 +6,14 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
 
     Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
     Includes [Email, EmailAddress]
+    Includes [PhoneNumber]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
         Property name String 0..1                                   "The name of the person organization."
         Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
-        Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
+        // Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
+        Property telephone PhoneNumber 0..1                         "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
         Property description String 0..1                            "A short description of the issuer entity or organization."
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         // Property email String 0..1                                  "Contact address for the individual or organization."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -6,20 +6,20 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
 
     Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
     Includes [Email, EmailAddress]
-    Includes [PhoneNumber]
+    Includes [Phone, PhoneNumber]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
         Property name String 0..1                                   "The name of the person organization."
         Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
         // Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
-        Property telephone PhoneNumber 0..1                         "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
+        Mixin Phone
         Property description String 0..1                            "A short description of the issuer entity or organization."
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         // Property email String 0..1                                  "Contact address for the individual or organization."
         Mixin Email
         // Property address Address 0..1                               "An address for the individual or organization."
-        Mixin PrimaryAddress
+        Mixin Address
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         Property birthDate Date 0..1                                "Birthdate of the person."
         Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -14,7 +14,6 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         Property email String 0..1                                  "Contact address for the individual or organization."
         // Property address Address 0..1                               "An address for the individual or organization."
-        // Mixin PrimaryAddress
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         Property birthDate Date 0..1                                "Birthdate of the person."
         Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,7 +4,7 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
-    Includes [PrimaryAddress, Address, AddressParts, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
+    Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
     Includes [Email, EmailAddress]
     Includes [Phone, PhoneNumber]
 
@@ -19,7 +19,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         // Property email String 0..1                                  "Contact address for the individual or organization."
         Mixin Email
         // Property address Address 0..1                               "An address for the individual or organization."
-        Mixin Address
+        Mixin PrimaryAddress
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         Property birthDate Date 0..1                                "Birthdate of the person."
         Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -2,4 +2,4 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 // Pull in common credential models (this will be converted to Includes when credential models are finalized and made part of the CDM)
 
-Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/develop/ob_v3p0/common_credentials.lines
+Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -5,7 +5,7 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
     Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
-    Includes [EmailAddress]
+    Includes [Email, EmailAddress]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
@@ -14,7 +14,8 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
         Property description String 0..1                            "A short description of the issuer entity or organization."
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
-        Property email String 0..1                                  "Contact address for the individual or organization."
+        // Property email String 0..1                                  "Contact address for the individual or organization."
+        Mixin Email
         // Property address Address 0..1                               "An address for the individual or organization."
         Mixin PrimaryAddress
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,7 +4,7 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
-    Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
+    Includes [PrimaryAddress, Address, AddressParts, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
     Includes [Email, EmailAddress]
     Includes [Phone, PhoneNumber]
 

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,7 +4,7 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
-    Includes [Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
+    Includes [Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress, PrimaryAddress]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,7 +4,7 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
-    Includes [Address, AddressTypeEnum, CountryCode, OptionallyTypedAddress]
+    Includes [Address, AddressTypeEnum, CountryCode, GeoCoordinates, OptionallyTypedAddress]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,7 +4,8 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
-    Includes [Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress, PrimaryAddress]
+    Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
+    Includes [EmailAddress]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -15,7 +15,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property name String 0..1                                   "The name of the person organization."
         Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
         // Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
-        Mixin PrimaryPhone
+        //Mixin PrimaryPhone
         Property description String 0..1                            "A short description of the issuer entity or organization."
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         // Property email String 0..1                                  "Contact address for the individual or organization."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -14,8 +14,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property image Image 0..1                                   "An image representing the entity. This must be a PNG or SVG image."
         // Property email String 0..1                                  "Contact address for the entity."
         Mixin Email
-        // Property address Address 0..1                               "An address for the individual or organization."
-        Mixin PrimaryAddress
+        Property address Address 0..1                               "An address for the individual or organization."
         // Property identifiers SystemIdentifier 0..*                  "A set of System Identifiers that represent other identifiers for this entity."
         Mixin OtherIdentifiers
         Property official String 0..1                               "If the entity is an organization, `official` is the name of an authorized official of the organization."
@@ -32,9 +31,9 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property sisSourcedId String 0..1                           "An institution's student identifier for the person. This is frequently issued through a Student Information System."
         Mixin Extensions
 
-    Includes [PrimaryAddress, Address, AddressTypeEnum, CountryCode, GeoCoordinates, OptionallyTypedAddress]
+    Includes [Address, CountryCode, GeoCoordinates]
     Includes [Email, EmailAddress]
-    Includes [Phone, PhoneNumber, OptionallyTypedPhone, PhoneType, PhoneTypeEnum]
+    Includes [Phone, PhoneNumber]
     Includes [SourcedId, UUID]
     Includes [OtherIdentifiers, IdentifierEntry, AnyIdentifier, IdentifierType, Identifier]
     Include IdentifierTypeEnum

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -14,6 +14,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         Property email String 0..1                                  "Contact address for the individual or organization."
         // Property address Address 0..1                               "An address for the individual or organization."
+        Mixin PrimaryAddress
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         Property birthDate Date 0..1                                "Birthdate of the person."
         Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,7 +4,7 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
-    Includes [Address, AddressTypeEnum, CountryCode, GeoCoordinates, OptionallyTypedAddress]
+    Includes [Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -15,7 +15,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property name String 0..1                                   "The name of the person organization."
         Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
         // Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
-        Mixin Phone
+        Mixin PrimaryPhone
         Property description String 0..1                            "A short description of the issuer entity or organization."
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         // Property email String 0..1                                  "Contact address for the individual or organization."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -15,7 +15,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         Property email String 0..1                                  "Contact address for the individual or organization."
         // Property address Address 0..1                               "An address for the individual or organization."
-        Mixin PrimaryAddress
+        //Mixin PrimaryAddress
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         Property birthDate Date 0..1                                "Birthdate of the person."
         Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,32 +4,39 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
-    Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
-    Includes [Email, EmailAddress]
-    Includes [Phone, PhoneNumber, OptionallyTypedPhone, PhoneType, PhoneTypeEnum]
-    Includes [SourcedId, UUID, Identifier]
-    Includes [Extensions]
-
-    Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
-        Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
-        Property name String 0..1                                   "The name of the person organization."
-        Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
+    Class Profile Unordered false []                                "A profile is a collection of information that describes a person or organization (an entity). Profiles are used to identify and describe issuers, holders, and creators."
+        Property id URI 1                                           "Unique URI for the entity described by this profile. Required so the entity can be the subject of an endorsement."
+        Property name String 0..1                                   "The name of the entity."
+        Property url URI 0..1                                       "The homepage or social media profile of the entity. Should be a URL/URI Accessible via HTTP."
         // Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
-        Mixin PrimaryPhone
-        Property description String 0..1                            "A short description of the issuer entity or organization."
-        Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
-        // Property email String 0..1                                  "Contact address for the individual or organization."
+        Mixin Phone
+        Property description String 0..1                            "A short description of the entity."
+        Property image Image 0..1                                   "An image representing the entity. This must be a PNG or SVG image."
+        // Property email String 0..1                                  "Contact address for the entity."
         Mixin Email
         // Property address Address 0..1                               "An address for the individual or organization."
         Mixin PrimaryAddress
-        Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
-        Property birthDate Date 0..1                                "Birthdate of the person."
-        Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."
-        Property givenName String 0..1                              "Given name of a person. In the U.S., the first name of a person."
-        Property identifiers SystemIdentifier 0..*                  "A set of System Identifiers that represent other identifiers for this Profile."
-        Property official String 0..1                               "The name of the authorized official for the Issuer."
-        Property parentOrg Profile 0..1                             "The parent organization of the person or organization represented by this organization."
-        // Property sourcedId String 0..1                              "The individual's or organization's unique `sourcedId` value, which is used for providing interoperability with other identity systems."
+        // Property identifiers SystemIdentifier 0..*                  "A set of System Identifiers that represent other identifiers for this entity."
+        Mixin OtherIdentifiers
+        Property official String 0..1                               "If the entity is an organization, `official` is the name of an authorized official of the organization."
+        Property parentOrg Profile 0..1                             "The parent organization of the entity."
+        // Property sourcedId String 0..1                              "The entity's unique `sourcedId` value, which is used for providing interoperability with other identity systems."
         Mixin SourcedId
-        Property studentId String 0..1                              "An institution's student identifier for the person. This is frequently issued through a Student Information System."
+        // Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
+        // Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."
+        // Property givenName String 0..1                              "Given name of a person. In the U.S., the first name of a person."
+        Mixin PersonNameParts
+        // Property birthDate Date 0..1                                "Birthdate of the person."
+        Property dateOfBirth Date 0..1                              ""Birthdate of the person."
+        // Property studentId String 0..1                              "An institution's student identifier for the person. This is frequently issued through a Student Information System."
+        Property sisSourcedId String 0..1                           "An institution's student identifier for the person. This is frequently issued through a Student Information System."
         Mixin Extensions
+
+    Includes [PrimaryAddress, Address, AddressTypeEnum, CountryCode, GeoCoordinates, OptionallyTypedAddress]
+    Includes [Email, EmailAddress]
+    Includes [Phone, PhoneNumber, OptionallyTypedPhone, PhoneType, PhoneTypeEnum]
+    Includes [SourcedId, UUID]
+    Includes [OtherIdentifiers, IdentifierEntry, AnyIdentifier, IdentifierType, Identifier]
+    Include IdentifierTypeEnum
+    Include PersonNameParts
+    Includes [Extensions, BaseTerm]

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -15,7 +15,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         Property email String 0..1                                  "Contact address for the individual or organization."
         // Property address Address 0..1                               "An address for the individual or organization."
-        //Mixin PrimaryAddress
+        Mixin PrimaryAddress
         Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         Property birthDate Date 0..1                                "Birthdate of the person."
         Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -7,7 +7,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
     Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
     Includes [Email, EmailAddress]
     Includes [Phone, PhoneNumber]
-    Includes [SourcedId, UUID]
+    Includes [SourcedId, UUID, Identifier]
     Includes [Extensions]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -7,6 +7,8 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
     Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
     Includes [Email, EmailAddress]
     Includes [Phone, PhoneNumber]
+    Includes [SourcedId]
+    Includes [Extensions]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
@@ -27,6 +29,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property identifiers SystemIdentifier 0..*                  "A set of System Identifiers that represent other identifiers for this Profile."
         Property official String 0..1                               "The name of the authorized official for the Issuer."
         Property parentOrg Profile 0..1                             "The parent organization of the person or organization represented by this organization."
-        Property sourcedId String 0..1                              "The individual's or organization's unique `sourcedId` value, which is used for providing interoperability with other identity systems."
+        // Property sourcedId String 0..1                              "The individual's or organization's unique `sourcedId` value, which is used for providing interoperability with other identity systems."
+        Mixin SourcedId
         Property studentId String 0..1                              "An institution's student identifier for the person. This is frequently issued through a Student Information System."
-        Property extensions Namespace 0..1
+        Mixin Extensions

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -3,3 +3,25 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 // Pull in common credential models (this will be converted to Includes when credential models are finalized and made part of the CDM)
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
+
+
+    Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
+        Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."
+        Property name String 0..1                                   "The name of the person organization."
+        Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
+        Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
+        Property description String 0..1                            "A short description of the issuer entity or organization."
+        Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
+        Property email String 0..1                                  "Contact address for the individual or organization."
+        // Property address Address 0..1                               "An address for the individual or organization."
+        // Mixin PrimaryAddress
+        Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
+        Property birthDate Date 0..1                                "Birthdate of the person."
+        Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."
+        Property givenName String 0..1                              "Given name of a person. In the U.S., the first name of a person."
+        Property identifiers SystemIdentifier 0..*                  "A set of System Identifiers that represent other identifiers for this Profile."
+        Property official String 0..1                               "The name of the authorized official for the Issuer."
+        Property parentOrg Profile 0..1                             "The parent organization of the person or organization represented by this organization."
+        Property sourcedId String 0..1                              "The individual's or organization's unique `sourcedId` value, which is used for providing interoperability with other identity systems."
+        Property studentId String 0..1                              "An institution's student identifier for the person. This is frequently issued through a Student Information System."
+        Property extensions Namespace 0..1

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -6,7 +6,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
 
     Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
     Includes [Email, EmailAddress]
-    Includes [Phone, PhoneNumber]
+    Includes [Phone, PhoneNumber, OptionallyTypedPhone, PhoneType, PhoneTypeEnum]
     Includes [SourcedId, UUID, Identifier]
     Includes [Extensions]
 

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -19,8 +19,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Mixin OtherIdentifiers
         Property official String 0..1                               "If the entity is an organization, `official` is the name of an authorized official of the organization."
         Property parentOrg Profile 0..1                             "The parent organization of the entity."
-        // Property sourcedId String 0..1                              "The entity's unique `sourcedId` value, which is used for providing interoperability with other identity systems."
-        Mixin SourcedId
+        Property sourcedId UUID 0..1                                "The sourcedId of the profile. This is the interoperability identifier that systems will refer to when making API calls, or when needing to identify an object. Systems SHOULD be able to map whichever local ids (e.g. database key fields) they use to sourcedId. The sourcedId of an object MUST be an anonymized or pseudonymized identifier of an entity and as such will not contain Personally Identifiable Information (PII) or Personal Data (PD)."
         // Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
         // Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."
         // Property givenName String 0..1                              "Given name of a person. In the U.S., the first name of a person."
@@ -34,7 +33,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
     Includes [Address, CountryCode, GeoCoordinates]
     Includes [Email, EmailAddress]
     Includes [Phone, PhoneNumber]
-    Includes [SourcedId, UUID]
+    Includes [UUID]
     Includes [OtherIdentifiers, IdentifierEntry, AnyIdentifier, IdentifierType, Identifier]
     Include IdentifierTypeEnum
     Include PersonNameParts

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -15,7 +15,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
         Property name String 0..1                                   "The name of the person organization."
         Property url URI 0..1                                       "The homepage or social media profile of the entity, whether individual or institutional. Should be a URL/URI Accessible via HTTP."
         // Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
-        //Mixin PrimaryPhone
+        Mixin PrimaryPhone
         Property description String 0..1                            "A short description of the issuer entity or organization."
         Property image Image 0..1                                   "An image representing the issuer. This must be a PNG or SVG image."
         // Property email String 0..1                                  "Contact address for the individual or organization."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -4,7 +4,7 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
 
-    Includes [Address, AddressTypeEnum, OptionallyTypedAddress]
+    Includes [Address, AddressTypeEnum, CountryCode, OptionallyTypedAddress]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."
         Property id URI 1                                           "Unique URI for the Issuer/Profile file. Required so the entity can be the subject of an endorsement."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -3,38 +3,3 @@ Model ob 2022-01-01 3.0 "s:IMS Base Document" "t:Open Badges" "d:Open Badges Dat
 // Pull in common credential models (this will be converted to Includes when credential models are finalized and made part of the CDM)
 
 Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/cdm-mixins/ob_v3p0/common_credentials.lines
-
-    Class Profile Unordered false []                                "A profile is a collection of information that describes a person or organization (an entity). Profiles are used to identify and describe issuers, holders, and creators."
-        Property id URI 1                                           "Unique URI for the entity described by this profile. Required so the entity can be the subject of an endorsement."
-        Property name String 0..1                                   "The name of the entity."
-        Property url URI 0..1                                       "The homepage or social media profile of the entity. Should be a URL/URI Accessible via HTTP."
-        // Property telephone String 0..1                              "A phone number for the entity. For maximum compatibility, the value should be expressed as a + and country code followed by the number with no spaces or other punctuation, like +16175551212 (E.164 format)."
-        Mixin Phone
-        Property description String 0..1                            "A short description of the entity."
-        Property image Image 0..1                                   "An image representing the entity. This must be a PNG or SVG image."
-        // Property email String 0..1                                  "Contact address for the entity."
-        Mixin Email
-        Property address Address 0..1                               "An address for the individual or organization."
-        // Property identifiers SystemIdentifier 0..*                  "A set of System Identifiers that represent other identifiers for this entity."
-        Mixin OtherIdentifiers
-        Property official String 0..1                               "If the entity is an organization, `official` is the name of an authorized official of the organization."
-        Property parentOrg Profile 0..1                             "The parent organization of the entity."
-        Property sourcedId UUID 0..1                                "The sourcedId of the profile. This is the interoperability identifier that systems will refer to when making API calls, or when needing to identify an object. Systems SHOULD be able to map whichever local ids (e.g. database key fields) they use to sourcedId. The sourcedId of an object MUST be an anonymized or pseudonymized identifier of an entity and as such will not contain Personally Identifiable Information (PII) or Personal Data (PD)."
-        // Property additionalName String 0..1                         "An additional name for a person, can be used for a middle name."
-        // Property familyName String 0..1                             "Family name of a person. In the U.S., the last name of a person."
-        // Property givenName String 0..1                              "Given name of a person. In the U.S., the first name of a person."
-        Mixin PersonNameParts
-        // Property birthDate Date 0..1                                "Birthdate of the person."
-        Property dateOfBirth Date 0..1                              ""Birthdate of the person."
-        // Property studentId String 0..1                              "An institution's student identifier for the person. This is frequently issued through a Student Information System."
-        Property sisSourcedId String 0..1                           "An institution's student identifier for the person. This is frequently issued through a Student Information System."
-        Mixin Extensions
-
-    Includes [Address, CountryCode, GeoCoordinates]
-    Includes [Email, EmailAddress]
-    Includes [Phone, PhoneNumber]
-    Includes [UUID]
-    Includes [OtherIdentifiers, IdentifierEntry, AnyIdentifier, IdentifierType, Identifier]
-    Include IdentifierTypeEnum
-    Include PersonNameParts
-    Includes [Extensions, BaseTerm]

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -7,7 +7,7 @@ Transclude https://raw.githubusercontent.com/IMSGlobal/openbadges-specification/
     Includes [PrimaryAddress, Address, AddressTypeEnum, BaseTerm, CountryCode, GeoCoordinates, OptionallyTypedAddress]
     Includes [Email, EmailAddress]
     Includes [Phone, PhoneNumber]
-    Includes [SourcedId]
+    Includes [SourcedId, UUID]
     Includes [Extensions]
 
     Class Profile Unordered false []                                "A profile is a collection of information that describes a person, entity, or organization."


### PR DESCRIPTION
Now that IMS has a Common Data Model (CDM), the architects will steer specs to use CDM data models wherever possible. And will review final spec data models for possible addition to the CDM.

@mgylling and I reviewed the Profile data model in OB 3.0 and found several opportunities to use the CDM. This PR has those changes. No data is lost.

Later in the OB 3.0 development process (nearer to Candidate Final) we will review the OB 3.0 data models for candidate additions to the CDM.