### PR TITLE
Define OpenBadgeCredential and AchievementCredential

### DIFF
--- a/ob_v3p0/context.json
+++ b/ob_v3p0/context.json
@@ -11,7 +11,8 @@
         "sec": "https://w3id.org/security#",
         "xsd" : "http://www.w3.org/2001/XMLSchema#",
 
-        "AchievementCredential": "obi:AchievementCredential",
+        "OpenBadgeCredential": "obi:OpenBadgeCredential",
+        "AchievementCredential": "OpenBadgeCredential",
         "EndorsementCredential": "obi:EndorsementCredential",
 
         "Achievement": "clr:Achievement",


### PR DESCRIPTION
Discussed in CLR project group on 3/31:

- OpenBadgeCredential in the "obi" namespace
- AchievementCredential is an alias for OpenBadgeCredential

```
        "OpenBadgeCredential": "obi:OpenBadgeCredential",
        "AchievementCredential": "OpenBadgeCredential",
```

Closes #381 and [CLR #269](https://github.com/IMSGlobal/ComprehensiveLearnerRecord/issues/269)