### PR TITLE
Use Endorsements API to exchange endorsements

### DIFF
--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -70,7 +70,8 @@ var api = `
       All secure endpoint requests MUST be made over secure TLS 1.2 or 1.3 protocol.
     </p>
     <p>
-      All of the Secure REST Endpoints endpoints are protected by OAuth 2.0 access tokens as described in [[[#api-security]]].
+      All of the Secure REST Endpoints endpoints are protected by OAuth 2.0 access tokens as described in
+      [[[#api-security]]].
     </p>
 
     <h4 id="scopes">Scopes</h4>
@@ -115,7 +116,7 @@ var api = `
         </tr>
       </tbody>
     </table>
-  
+
     <!-- getAssertions -->
     <section>
       <h3 id="getassertions">getAssertions</h3>
@@ -183,10 +184,10 @@ var api = `
             <td>Required</td>
           </tr>
           <tr>
-            <td><code>Accept: application/ld+json</code></td>
+            <td><code>Accept: application/ld+json, text/plain</code></td>
             <td>
-              If the content type <code>application/ld+json</code> is not not included in the <code>Accept</code>
-              header, the [=resource server=] MUST respond with 406 Not Acceptable.
+              If the content types <code>application/ld+json</code> and <code>text/plain</code> are not not included in
+              the <code>Accept</code> header, the [=resource server=] MUST respond with 406 Not Acceptable.
             </td>
             <td>Required</td>
           </tr>
@@ -203,7 +204,7 @@ var api = `
         GET {tenant}/ims/ob/v3p0/assertions?limit=2&offset=0 HTTP/1.1
         Host: example.com
         Authorization: Bearer 863DF0B10F5D432EB2933C2A37CD3135A7BB7B07A68F65D92
-        Accept: application/ld+json
+        Accept: application/ld+json, text/plain
       </pre>
 
       <h4 id="getassertions-responses">Responses</h4>
@@ -220,10 +221,16 @@ var api = `
         <tbody>
           <tr>
             <td>200</td>
-            <td><a href="#org.1edtech.ob.v3p0.presentationjwspayload.class">PresentationJwsPayload</a></td>
             <td>
-              &#39;OK&#39; - The signed AssertionCredentials are returned in the payload. The assertions MUST be signed
-              with [[[#jwt-proof]]]. They MAY also be signed with Linked Data Proofs.
+              <a href="#verifiablepresentation">VerifiablePresentation</a>,
+              <a href="#presentationjwspayload">PresentationJwsPayload</a>, or
+              <a href="#compactjws">CompactJws</a>
+            </td>
+            <td>
+              &#39;OK&#39; - The signed AssertionCredentials are returned in the payload. 
+              If the presentation is signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>text/plain</code> and payload MUST be a <code>CompactJws</code>.
+              If the presentation and the nested credentials are signed with an embedded [[[#lds-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be a <code>VerifiablePresentation</code>.
+              if the presentation is not signed, but the AssertionCredentials are signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be <code>PresentationJwsPayload</code>.
             </td>
             <td>Required</td>
           </tr>
@@ -290,8 +297,14 @@ var api = `
         </thead>
         <tbody>
           <tr>
-            <td><code>Content-Type: application/ld+json</code></td>
-            <td>The content type MUST be <code>application/ld+json</code>.</td>
+            <td>
+              <code>Content-Type: application/ld+json</code> or
+              <code>Content-Type: text/plain</code>
+            </td>
+            <td>
+              The content type MUST be <code>application/ld+json</code> or <code>text/plain</code>.
+              See <code>HTTP 200</code> Response for details.
+            </td>
             <td>Required</td>
           </tr>
           <tr>
@@ -354,7 +367,7 @@ var api = `
 
       <h4>Sample Response</h4>
 
-      <pre class="http example" title="Sample getAssertions Response (line breaks for clarity)">
+      <pre class="http example" title="Sample getAssertions Response with PresentationJwsPayload (line breaks for clarity)">
         HTTP/1.1 200 OK
         Content-Type: application/ld+json
         X-Total-Count: 1
@@ -370,7 +383,9 @@ var api = `
           ],
           "type": ["VerifiablePresentation"],
           "verifiableCredential": [
+
             // Signed AssertionCredentials in Compact JWS format
+
             "header.payload.signature",
             "header.payload.signature"
           ]
@@ -383,7 +398,8 @@ var api = `
       <h3 id="postassertion">postAssertion</h3>
       <p>Create or update an AssertionCredential on the [=resource server=].</p>
       <p>
-        If the [=resource server=] is holding an AssertionCredential with the same <code>id</code>, it will be updated. Otherwise
+        If the [=resource server=] is holding an AssertionCredential with the same <code>id</code>, it will be updated.
+        Otherwise
         the [=resource server=] will store the AssertionCredential in the request payload as a resource.
       </p>
 
@@ -499,7 +515,8 @@ var api = `
             <td>200</td>
             <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
             <td>
-              &#39;OK&#39; - The AssertionCredential was successfully updated. The response payload MUST be the AssertionCredential that
+              &#39;OK&#39; - The AssertionCredential was successfully updated. The response payload MUST be the
+              AssertionCredential that
               was posted.
             </td>
             <td>Required</td>
@@ -508,7 +525,8 @@ var api = `
             <td>201</td>
             <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
             <td>
-              &#39;Created&#39; - The AssertionCredential was successfully created. The response payload MUST be the AssertionCredential
+              &#39;Created&#39; - The AssertionCredential was successfully created. The response payload MUST be the
+              AssertionCredential
               that was posted.
             </td>
             <td>Required</td>

--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -135,7 +135,8 @@ var api = `
     <section>
       <h3 id="getassertions">getAssertions</h3>
       <p>
-        Fetch AssertionCredentials and their EndorsementCredentials from the [=resource server=] for the supplied parameters and access token.
+        Fetch AssertionCredentials and their EndorsementCredentials from the [=resource server=] for the supplied
+        parameters and access token.
       </p>
 
       <h4 id="getassertions-request">Request Format</h4>
@@ -241,10 +242,16 @@ var api = `
               <a href="#compactjws">CompactJws</a>
             </td>
             <td>
-              &#39;OK&#39; - The signed AssertionCredentials and the signed EndorsementCredentials for the AssertionCredentials, their Achievements, and their Issuers are returned in the payload. 
-              If the presentation is signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>text/plain</code> and payload MUST be a <code>CompactJws</code>.
-              If the presentation and the nested credentials are signed with an embedded [[[#lds-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be a <code>VerifiablePresentation</code>.
-              if the presentation is not signed, but the AssertionCredentials are signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be <code>PresentationJwsPayload</code>.
+              &#39;OK&#39; - The signed AssertionCredentials and the signed EndorsementCredentials for the
+              AssertionCredentials, their Achievements, and their Issuers are returned in the payload.
+              If the presentation is signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be
+              <code>text/plain</code> and payload MUST be a <code>CompactJws</code>.
+              If the presentation and the nested credentials are signed with an embedded [[[#lds-proof]]], the
+              <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be a
+              <code>VerifiablePresentation</code>.
+              if the presentation is not signed, but the AssertionCredentials are signed with [[[#jwt-proof]]], the
+              <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be
+              <code>PresentationJwsPayload</code>.
             </td>
             <td>Required</td>
           </tr>
@@ -381,7 +388,8 @@ var api = `
 
       <h4>Sample Response</h4>
 
-      <pre class="http example" title="Sample getAssertions Response with PresentationJwsPayload (line breaks for clarity)">
+      <pre class="http example"
+        title="Sample getAssertions Response with PresentationJwsPayload (line breaks for clarity)">
         HTTP/1.1 200 OK
         Content-Type: application/ld+json
         X-Total-Count: 1
@@ -636,10 +644,16 @@ var api = `
       <p>
         Fetch the EndorsementCredentials from the [=resource server=] for the supplied parameters and access token.
       </p>
+      <div class="note">
+        The [=resource server=] MUST only return one form of signed endorsement at a time. If you want endorsements that
+        are signed with [[[#jwt-proof]]] and [[[#lds-proof]]], you will need to call this endpoint twice; once with
+        <code>Accept: text/plain</code> and once with <code>Accept: application/ld+json</code>.
+      </div>
 
       <h4 id="getendorsements-request">Request Format</h4>
 
-      <p><code>GET {baseUrl}/ims/ob/v3p0/endorsements/{id}?limit={limit}&amp;offset={offset}&amp;since={since}</code></p>
+      <p><code>GET {baseUrl}/ims/ob/v3p0/endorsements/{id}?limit={limit}&amp;offset={offset}&amp;since={since}</code>
+      </p>
       <table class="simple">
         <thead>
           <tr>
@@ -662,7 +676,8 @@ var api = `
             <td><code>id</code></td>
             <td><a href="#string">String</a></td>
             <td>
-              The URL Encoded [[RFC1738]] `id` of the AchievementCredential, Achievement, or Profile that is the subject of the EndorsementCredential.
+              The URL Encoded [[RFC1738]] <code>id</code> of the AchievementCredential, Achievement, or Profile that is
+              the subject of the EndorsementCredential.
             </td>
           </tr>
           <tr>
@@ -704,10 +719,15 @@ var api = `
             <td>Required</td>
           </tr>
           <tr>
-            <td><code>Accept: application/ld+json, text/plain</code></td>
             <td>
-              If the content types <code>application/ld+json</code> and <code>text/plain</code> are not not included in
-              the <code>Accept</code> header, the [=resource server=] MUST respond with 406 Not Acceptable.
+              <code>Accept: application/ld+json</code> or
+              <code>Accept: text/plain</code>
+            </td>
+            <td>
+              Use <code>Accept: application/ld+json</code> if you want endorsements that were signed with
+              [[[#lds-proof]]], and <code>Accept: text/plain</code> if you want endorsement that were signedd with
+              [[[#jwt-proof]]]. If neither content type is acceptable, or if both content types are acceptable, the
+              [=resource server=] MUST respond with 406 Not Acceptable.
             </td>
             <td>Required</td>
           </tr>
@@ -720,11 +740,11 @@ var api = `
 
       <h4>Sample Request</h4>
 
-      <pre class="http example" title="Sample getAssertions Request">
+      <pre class="http example" title="Sample getEndorsements Request">
         GET {tenant}/ims/ob/v3p0/endorsements/urn%3Auuid%3A84396210-1f79-4dbf-8b84-3aac2f5cbd0f/?limit=2&offset=0 HTTP/1.1
         Host: example.com
         Authorization: Bearer 863DF0B10F5D432EB2933C2A37CD3135A7BB7B07A68F65D92
-        Accept: application/ld+json, text/plain
+        Accept: text/plain
       </pre>
 
       <h4 id="getendorsements-responses">Responses</h4>
@@ -742,15 +762,16 @@ var api = `
           <tr>
             <td>200</td>
             <td>
-              <a href="#verifiablepresentation">VerifiablePresentation</a>,
-              <a href="#presentationjwspayload">PresentationJwsPayload</a>, or
-              <a href="#compactjws">CompactJws</a>
+              <a href="#verifiablepresentation">VerifiablePresentation</a> or
+              <a href="#presentationjwspayload">PresentationJwsPayload</a>
             </td>
             <td>
-              &#39;OK&#39; - The signed EndorsementCredentials are returned in the payload. 
-              If the presentation is signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>text/plain</code> and payload MUST be a <code>CompactJws</code>.
-              If the presentation and the nested credentials are signed with an embedded [[[#lds-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be a <code>VerifiablePresentation</code>.
-              if the presentation is not signed, but the nested credentials are signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be <code>PresentationJwsPayload</code>.
+              &#39;OK&#39; - The signed EndorsementCredentials are returned in the payload.
+              If the request <code>Accept</code> header includes <code>text/plain</code>, the payload MUST only include
+              endorsements signed with [[[#jwt-proof]]] and the payload MUST be a <code>PresentationJwsPayload</code>.
+              If the request <code>Accept</code> header includes <code>application/ld+json</code>, the payload MUST only
+              include endorsements signed with [[[#lds-proof]]] and the payload MUST be a
+              <code>VerifiablePresentation</code>.
             </td>
             <td>Required</td>
           </tr>
@@ -773,8 +794,7 @@ var api = `
             <td>403</td>
             <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
             <td>
-              &#39;Forbidden&#39; - The [=resource server=] understood the request, but is refusing it or the access
-              is
+              &#39;Forbidden&#39; - The [=resource server=] understood the request, but is refusing it or the access is
               not allowed.
             </td>
             <td>Required</td>
@@ -782,7 +802,7 @@ var api = `
           <tr>
             <td>404</td>
             <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
-            <td>&#39;Not Found&#39; - There are no endorsements for the specified `id`.</td>
+            <td>&#39;Not Found&#39; - There are no endorsements for the specified subject <code>id</code>.</td>
             <td>Required</td>
           </tr>
           <tr>
@@ -818,12 +838,12 @@ var api = `
         <tbody>
           <tr>
             <td>
-              <code>Content-Type: application/ld+json</code> or
-              <code>Content-Type: text/plain</code>
+              <code>Content-Type: application/json</code> or
+              <code>Content-Type: application/ld+json</code>
             </td>
             <td>
-              The content type MUST be <code>application/ld+json</code> or <code>text/plain</code>.
-              See <code>HTTP 200</code> Response for details.
+              If the request is successful, the content type MUST be <code>application/ld+json</code>. Otherwise the
+              content type MUST be <code>application/json</code>.
             </td>
             <td>Required</td>
           </tr>
@@ -862,8 +882,7 @@ var api = `
           <tr>
             <td>next</td>
             <td>
-              The link relation for the immediate next page of results. This MUST appear when the current list
-              response
+              The link relation for the immediate next page of results. This MUST appear when the current list response
               is incomplete.
             </td>
           </tr>
@@ -887,7 +906,8 @@ var api = `
 
       <h4>Sample Response</h4>
 
-      <pre class="http example" title="Sample getAssertions Response with PresentationJwsPayload (line breaks for clarity)">
+      <pre class="http example"
+        title="Sample getAssertions Response with PresentationJwsPayload (line breaks for clarity)">
         HTTP/1.1 200 OK
         Content-Type: application/ld+json
         X-Total-Count: 1
@@ -901,7 +921,7 @@ var api = `
             "https://www.w3.org/2018/credentials/v1",
             "https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld"
           ],
-          "type": ["VerifiablePresentation"],
+          "type": ["VerifiablePresentation", "PresentationJwsPayload"],
           "verifiableCredential": [
 
             // Signed Endorsements in Compact JWS format
@@ -918,9 +938,9 @@ var api = `
       <h3 id="postendorsement">postEndorsement</h3>
       <p>Create or update an EndorsementCredential on the [=resource server=].</p>
       <p>
-        If the [=resource server=] is holding an EndorsementCredential with the same <code>id</code>, it will be updated.
-        Otherwise
-        the [=resource server=] will store the EndorsementCredential in the request payload as a resource.
+        If the [=resource server=] is holding an EndorsementCredential with the same <code>id</code>, it will be
+        updated. Otherwise the [=resource server=] will store the EndorsementCredential in the request payload as a
+        resource.
       </p>
 
       <h4 id="postassertion-request">Request Format</h4>
@@ -966,18 +986,26 @@ var api = `
             <td>Required</td>
           </tr>
           <tr>
-            <td><code>Accept: application/ld+json, text/plain</code></td>
             <td>
-              If the content types <code>application/ld+json</code> and <code>text/plain</code> is not not included in the <code>Accept</code>
-              header, the [=resource server=] MUST respond with 406 Not Acceptable.
+              <code>Accept: application/ld+json</code> or
+              <code>Accept: text/plain</code>
+            </td>
+            <td>
+              If the <code>Accept</code> header does not include the <code>Content-Type</code> the [=resource server=]
+              MUST respond with 406 Not Acceptable.
             </td>
             <td>Required</td>
           </tr>
           <tr>
-            <td><code>Content-Type: application/ld+json</code></td>
             <td>
-              If the <code>Content-Type</code> is not <code>application/ld+json</code>, the [=resource server=] MUST
-              respond with 406 Not Acceptable.
+              <code>Content-Type: application/ld+json</code> or
+              <code>Content-Type: text/plain</code>
+            </td>
+            <td>
+              If the endorsement has been signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be
+              <code>text/plain</code>. Otherwise the <code>Content-Type</code> MUST be <code>application/ld+json</code>.
+              If the <code>Content-Type</code> is neither <code>text/plain</code> or <code>application/ld+json</code>,
+              the [=resource server=] MUST respond with 406 Not Acceptable.
             </td>
             <td>Required</td>
           </tr>
@@ -996,10 +1024,14 @@ var api = `
         </thead>
         <tbody>
           <tr>
-            <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
             <td>
-              The AssertionCredential to be updated or created on the [=resource server=]. The AssertionCredential
-              MUST be signed with [[[#jwt-proof]]].
+              <a href="#compactjws">CompactJws</a> or
+              <a href="#endorsementcredential">EndorsementCredential</a>
+            </td>
+            <td>
+              The EndorsementCredential to be updated or created on the [=resource server=]. If the endorsement has been
+              signed with [[[#jwt-proof]]], the payload type MUST be <code>CompactJws</code>. Otherwise the payload type
+              MUST be <code>EndorsementCredential</code>.
             </td>
             <td>Required</td>
           </tr>
@@ -1009,17 +1041,18 @@ var api = `
       <h4>Sample Request</h4>
 
       <pre class="http example" title="Sample postAssertion Request">
-          POST {tenant}/ims/ob/v3p0/assertions HTTP/1.1
+          POST {tenant}/ims/ob/v3p0/endorsements HTTP/1.1
           Host: example.com
           Authorization: Bearer 863DF0B10F5D432EB2933C2A37CD3135A7BB7B07A68F65D92
           Accept: text/plain
           Content-Type: text/plain
 
-          // The AssertionCredential in Compact JWS format
+          // The EndorsementCredential in Compact JWS format
+
           header.payload.signature
         </pre>
 
-      <h4 id="postassertion-responses">Responses</h4>
+      <h4 id="postendorsement-responses">Responses</h4>
 
       <table class="simple">
         <thead>
@@ -1033,21 +1066,25 @@ var api = `
         <tbody>
           <tr>
             <td>200</td>
-            <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
             <td>
-              &#39;OK&#39; - The AssertionCredential was successfully updated. The response payload MUST be the
-              AssertionCredential that
-              was posted.
+              <a href="#compactjws">CompactJws</a> or
+              <a href="#endorsementcredential">EndorsementCredential</a>
+            </td>
+            <td>
+              &#39;OK&#39; - The EndorsementCredential was successfully updated. The response payload MUST be the
+              EndorsementCredential that was posted. The response payload type MUST match the request payload type.
             </td>
             <td>Required</td>
           </tr>
           <tr>
             <td>201</td>
-            <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
             <td>
-              &#39;Created&#39; - The AssertionCredential was successfully created. The response payload MUST be the
-              AssertionCredential
-              that was posted.
+              <a href="#compactjws">CompactJws</a> or
+              <a href="#endorsementcredential">EndorsementCredential</a>
+            </td>
+            <td>
+              &#39;OK&#39; - The EndorsementCredential was successfully created. The response payload MUST be the
+              EndorsementCredential that was posted. The response payload type MUST match the request payload type.
             </td>
             <td>Required</td>
           </tr>
@@ -1113,8 +1150,16 @@ var api = `
         </thead>
         <tbody>
           <tr>
-            <td><code>Content-Type: text/plain</code></td>
-            <td>The content type MUST be <code>text/plain</code>.</td>
+            <td>
+              <code>Content-Type: text/plain</code>,
+              <code>Content-Type: application/json</code>, or
+              <code>Content-Type: application/ld+json</code>
+            </td>
+            <td>
+              If the response status is successfull, the response <code>Content-Type</code> MUST match the request
+              <code>Content-Type</code>. Otherwise the response <code>Content-Type</code> MUST be
+              <code>application/json</code>.
+            </td>
             <td>Required</td>
           </tr>
         </tbody>
@@ -1122,11 +1167,12 @@ var api = `
 
       <h4>Sample Response</h4>
 
-      <pre class="http example" title="Sample postAssertion Response">
+      <pre class="http example" title="Sample postEndorsement Response">
         HTTP/1.1 200 OK
         Content-Type: text/plain
 
-        // The AssertionCredential in Compact JWS format
+        // The EndorsementCredential in Compact JWS format
+
         header.payload.signature
       </pre>
     </section>

--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -90,7 +90,7 @@ var api = `
           <td><a href="#getassertions">getAssertions</a></td>
           <td>
             <code>https://purl.imsglobal.org/spec/ob/v3p0/scope/assertion.readonly</code> -
-            Permission to read assertions for the authenticated entity.
+            Permission to read assertions and their endorsements for the authenticated entity.
           </td>
         </tr>
         <tr>
@@ -98,6 +98,20 @@ var api = `
           <td>
             <code>https://purl.imsglobal.org/spec/ob/v3p0/scope/assertion.create</code> -
             Permission to create assertions for the authenticated entity.
+          </td>
+        </tr>
+        <tr>
+          <td><a href="#getendorsements">getEndorsements</a></td>
+          <td>
+            <code>https://purl.imsglobal.org/spec/ob/v3p0/scope/endorsement.readonly</code> -
+            Permission to read endorsements for the authenticated entity.
+          </td>
+        </tr>
+        <tr>
+          <td><a href="#postendorsement">postEndorsement</a></td>
+          <td>
+            <code>https://purl.imsglobal.org/spec/ob/v3p0/scope/endorsement.create</code> -
+            Permission to create endorsements for the authenticated entity.
           </td>
         </tr>
         <tr>
@@ -121,7 +135,7 @@ var api = `
     <section>
       <h3 id="getassertions">getAssertions</h3>
       <p>
-        Fetch AssertionCredentials from the [=resource server=] for the supplied parameters and access token.
+        Fetch AssertionCredentials and their EndorsementCredentials from the [=resource server=] for the supplied parameters and access token.
       </p>
 
       <h4 id="getassertions-request">Request Format</h4>
@@ -227,7 +241,7 @@ var api = `
               <a href="#compactjws">CompactJws</a>
             </td>
             <td>
-              &#39;OK&#39; - The signed AssertionCredentials are returned in the payload. 
+              &#39;OK&#39; - The signed AssertionCredentials and the signed EndorsementCredentials for the AssertionCredentials, their Achievements, and their Issuers are returned in the payload. 
               If the presentation is signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>text/plain</code> and payload MUST be a <code>CompactJws</code>.
               If the presentation and the nested credentials are signed with an embedded [[[#lds-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be a <code>VerifiablePresentation</code>.
               if the presentation is not signed, but the AssertionCredentials are signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be <code>PresentationJwsPayload</code>.
@@ -385,6 +399,11 @@ var api = `
           "verifiableCredential": [
 
             // Signed AssertionCredentials in Compact JWS format
+
+            "header.payload.signature",
+            "header.payload.signature",
+
+            // Signed EndorsementCredentials in Compact JWS format
 
             "header.payload.signature",
             "header.payload.signature"
@@ -611,8 +630,508 @@ var api = `
       </pre>
     </section>
 
-    <!-- getProfile -->
+    <!-- getEndorsements -->
+    <section>
+      <h3 id="getendorsements">getEndorsements</h3>
+      <p>
+        Fetch the EndorsementCredentials from the [=resource server=] for the supplied parameters and access token.
+      </p>
 
+      <h4 id="getendorsements-request">Request Format</h4>
+
+      <p><code>GET {baseUrl}/ims/ob/v3p0/endorsements/{id}?limit={limit}&amp;offset={offset}&amp;since={since}</code></p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>URL Parameter</th>
+            <th>Parameter Type</th>
+            <th>Description</th>
+            <th>Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>baseUrl</code></td>
+            <td><a href="#org.1edtech.ob.v3p0.derived.url.class">URL</a></td>
+            <td>The HTTP scheme (which MUST be "https"), domain name, and any other path
+              elements required by the [=resource server=] (e.g. "https://example.com/tenant").
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td><code>id</code></td>
+            <td><a href="#string">String</a></td>
+            <td>
+              The URL Encoded [[RFC1738]] `id` of the AchievementCredential, Achievement, or Profile that is the subject of the EndorsementCredential.
+            </td>
+          </tr>
+          <tr>
+            <td><code>limit</code></td>
+            <td><a href="#org.1edtech.ob.v3p0.primitive.positiveinteger.class">PositiveInteger</a></td>
+            <td>The maximum number of endorsements to return.</td>
+            <td>Optional</td>
+          </tr>
+          <tr>
+            <td><code>offset</code></td>
+            <td><a href="#org.1edtech.ob.v3p0.primitive.nonnegativeinteger.class">NonNegativeInteger</a>
+            </td>
+            <td>The index of the first endorsement to return. (zero indexed)</td>
+            <td>Optional</td>
+          </tr>
+          <tr>
+            <td><code>since</code></td>
+            <td><a href="#org.1edtech.ob.v3p0.primitive.datetime.class">DateTime</a></td>
+            <td>Only include endorsements issued after this timestamp.</td>
+            <td>Optional</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Request Headers</h4>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Request Header</th>
+            <th>Description</th>
+            <th>Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Authorization: Bearer &lt;access_token&gt;</code></td>
+            <td>See [[[#api-security]]] for information on how to obtain an <code>access_token</code>.</td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td><code>Accept: application/ld+json, text/plain</code></td>
+            <td>
+              If the content types <code>application/ld+json</code> and <code>text/plain</code> are not not included in
+              the <code>Accept</code> header, the [=resource server=] MUST respond with 406 Not Acceptable.
+            </td>
+            <td>Required</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Request Payload</h4>
+
+      <p>There is no request payload.</p>
+
+      <h4>Sample Request</h4>
+
+      <pre class="http example" title="Sample getAssertions Request">
+        GET {tenant}/ims/ob/v3p0/endorsements/urn%3Auuid%3A84396210-1f79-4dbf-8b84-3aac2f5cbd0f/?limit=2&offset=0 HTTP/1.1
+        Host: example.com
+        Authorization: Bearer 863DF0B10F5D432EB2933C2A37CD3135A7BB7B07A68F65D92
+        Accept: application/ld+json, text/plain
+      </pre>
+
+      <h4 id="getendorsements-responses">Responses</h4>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>HTTP Status Code</th>
+            <th>Payload Type</th>
+            <th>Description</th>
+            <th>Payload Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>200</td>
+            <td>
+              <a href="#verifiablepresentation">VerifiablePresentation</a>,
+              <a href="#presentationjwspayload">PresentationJwsPayload</a>, or
+              <a href="#compactjws">CompactJws</a>
+            </td>
+            <td>
+              &#39;OK&#39; - The signed EndorsementCredentials are returned in the payload. 
+              If the presentation is signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>text/plain</code> and payload MUST be a <code>CompactJws</code>.
+              If the presentation and the nested credentials are signed with an embedded [[[#lds-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be a <code>VerifiablePresentation</code>.
+              if the presentation is not signed, but the nested credentials are signed with [[[#jwt-proof]]], the <code>Content-Type</code> MUST be <code>application/ld+json</code> and the payload MUST be <code>PresentationJwsPayload</code>.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>400</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>
+              &#39;Bad Request&#39; - The request was invalid or cannot be served. The exact error should be explained
+              in the response payload.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>401</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>&#39;Unauthorized&#39; - The request requires user authentication.</td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>403</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>
+              &#39;Forbidden&#39; - The [=resource server=] understood the request, but is refusing it or the access
+              is
+              not allowed.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>404</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>&#39;Not Found&#39; - There are no endorsements for the specified `id`.</td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>406</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>
+              &#39;Not Acceptable&#39; - The request did not include &#39;application/ld+json&#39; in the Accept
+              header.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>421</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>
+              &#39;Misdirected Request&#39; - The request was not made over secure TLS 1.2 or 1.3 protocol.
+            </td>
+            <td>Required</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Response Headers</h4>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Response Header</th>
+            <th>Description</th>
+            <th>Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>Content-Type: application/ld+json</code> or
+              <code>Content-Type: text/plain</code>
+            </td>
+            <td>
+              The content type MUST be <code>application/ld+json</code> or <code>text/plain</code>.
+              See <code>HTTP 200</code> Response for details.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td><code>X-Total-Count: &lt;total_count&gt;</code></td>
+            <td>
+              The [=resource server=] MUST include an <code>X-Total-Count</code> response header if the total result
+              count is known. If the total result count is not known, the total count header MUST be ommitted.
+            </td>
+            <td>Conditionally Required for <code>200 OK</code> Response</td>
+          </tr>
+          <tr>
+            <td><code>Link: &lt;pagination_links&gt;</code></td>
+            <td>
+              The [=resource server=] MUST include a
+              <code><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link">Link</a></code> response
+              header if the list of endorsements in the response is incomplete; and MAY include the <code>Link</code>
+              header if the response is complete.
+            </td>
+            <td>Conditionally Required for <code>200 OK</code> Response</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        If present, the <code>Link</code> header MUST support all of the following link relations (<code>rel</code>
+        values):
+      </p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Relation</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>next</td>
+            <td>
+              The link relation for the immediate next page of results. This MUST appear when the current list
+              response
+              is incomplete.
+            </td>
+          </tr>
+          <tr>
+            <td>last</td>
+            <td>The link relation for the last page of results. This MUST always appear.</td>
+          </tr>
+          <tr>
+            <td>first</td>
+            <td>The link relation for the first page of results. This MUST always appear.</td>
+          </tr>
+          <tr>
+            <td>prev</td>
+            <td>
+              The link relation for the immediate previous page of results. This MUST appear when the
+              offset is greater than zero.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Sample Response</h4>
+
+      <pre class="http example" title="Sample getAssertions Response with PresentationJwsPayload (line breaks for clarity)">
+        HTTP/1.1 200 OK
+        Content-Type: application/ld+json
+        X-Total-Count: 1
+        Link: &lt;https://www.imsglobal.org/ims/ob/v3p0/assertions?limit=2&offset=1>; rel="next",
+              &lt;https://www.imsglobal.org/ims/ob/v3p0/assertions?limit=2&offset=0>; rel="last",
+              &lt;https://www.imsglobal.org/ims/ob/v3p0/assertions?limit=2&offset=0>; rel="first",
+              &lt;https://www.imsglobal.org/ims/ob/v3p0/assertions?limit=2&offset=0>; rel="prev"
+
+        {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld"
+          ],
+          "type": ["VerifiablePresentation"],
+          "verifiableCredential": [
+
+            // Signed Endorsements in Compact JWS format
+
+            "header.payload.signature",
+            "header.payload.signature"
+          ]
+        }
+      </pre>
+    </section>
+
+    <!-- postEndorsement -->
+    <section>
+      <h3 id="postendorsement">postEndorsement</h3>
+      <p>Create or update an EndorsementCredential on the [=resource server=].</p>
+      <p>
+        If the [=resource server=] is holding an EndorsementCredential with the same <code>id</code>, it will be updated.
+        Otherwise
+        the [=resource server=] will store the EndorsementCredential in the request payload as a resource.
+      </p>
+
+      <h4 id="postassertion-request">Request Format</h4>
+
+      <p><code>POST {baseUrl}/ims/ob/v3p0/endorsements</code></p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>URL Parameter</th>
+            <th>Parameter Type</th>
+            <th>Description</th>
+            <th>Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>baseUrl</code></td>
+            <td><a href="#org.1edtech.ob.v3p0.derived.url.class">URL</a></td>
+            <td>
+              The HTTP scheme (which MUST be &quot;https&quot;), the domain name, and any other path elements required
+              by the [=resource server=] (e.g. &quot;<a
+                href="https://example.com/tenant">https://example.com/tenant</a>&quot;).
+            </td>
+            <td>Required</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Request Headers</h4>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Request Header</th>
+            <th>Description</th>
+            <th>Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Authorization: Bearer &lt;access_token&gt;</code></td>
+            <td>See [[[#api-security]]] for information on how to obtain an <code>access_token</code>.</td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td><code>Accept: application/ld+json, text/plain</code></td>
+            <td>
+              If the content types <code>application/ld+json</code> and <code>text/plain</code> is not not included in the <code>Accept</code>
+              header, the [=resource server=] MUST respond with 406 Not Acceptable.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td><code>Content-Type: application/ld+json</code></td>
+            <td>
+              If the <code>Content-Type</code> is not <code>application/ld+json</code>, the [=resource server=] MUST
+              respond with 406 Not Acceptable.
+            </td>
+            <td>Required</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Request Payload</h4>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Request Payload Type</th>
+            <th>Description</th>
+            <th>Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
+            <td>
+              The AssertionCredential to be updated or created on the [=resource server=]. The AssertionCredential
+              MUST be signed with [[[#jwt-proof]]].
+            </td>
+            <td>Required</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Sample Request</h4>
+
+      <pre class="http example" title="Sample postAssertion Request">
+          POST {tenant}/ims/ob/v3p0/assertions HTTP/1.1
+          Host: example.com
+          Authorization: Bearer 863DF0B10F5D432EB2933C2A37CD3135A7BB7B07A68F65D92
+          Accept: text/plain
+          Content-Type: text/plain
+
+          // The AssertionCredential in Compact JWS format
+          header.payload.signature
+        </pre>
+
+      <h4 id="postassertion-responses">Responses</h4>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>HTTP Status Code</th>
+            <th>Payload Type</th>
+            <th>Description</th>
+            <th>Payload Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>200</td>
+            <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
+            <td>
+              &#39;OK&#39; - The AssertionCredential was successfully updated. The response payload MUST be the
+              AssertionCredential that
+              was posted.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>201</td>
+            <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
+            <td>
+              &#39;Created&#39; - The AssertionCredential was successfully created. The response payload MUST be the
+              AssertionCredential
+              that was posted.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>400</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>
+              &#39;Bad Request&#39; - The request was invalid or cannot be served. The exact error should
+              be explained in the response payload.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>401</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>&#39;Unauthorized&#39; - The request requires user authentication.</td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>403</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>
+              &#39;Forbidden&#39; - The [=resource server=] understood the request, but is refusing it or the access
+              is not allowed.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>405</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>&#39;Method Not Allowed&#39; - The [=resource server=] does not support this operation.</td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>406</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>
+              &#39;Not Acceptable&#39; - The request did not include &#39;application/ld+json&#39; in the Accept
+              header.
+            </td>
+            <td>Required</td>
+          </tr>
+          <tr>
+            <td>421</td>
+            <td><a href="#org.1edtech.ob.v3p0.imsx_statusinfo.class">Imsx_StatusInfo</a></td>
+            <td>
+              &#39;Misdirected Request&#39; - The request was not made over secure TLS 1.2 or 1.3 protocol.
+            </td>
+            <td>Required</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Response Headers</h4>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Response Header</th>
+            <th>Description</th>
+            <th>Required</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Content-Type: text/plain</code></td>
+            <td>The content type MUST be <code>text/plain</code>.</td>
+            <td>Required</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Sample Response</h4>
+
+      <pre class="http example" title="Sample postAssertion Response">
+        HTTP/1.1 200 OK
+        Content-Type: text/plain
+
+        // The AssertionCredential in Compact JWS format
+        header.payload.signature
+      </pre>
+    </section>
+
+    <!-- getProfile -->
     <section>
       <h3 id="getprofile">getProfile</h3>
 

--- a/ob_v3p0/datamodel.html
+++ b/ob_v3p0/datamodel.html
@@ -35,12 +35,12 @@ var datamodel = `
     The data models in this section are shared by all IMS service specifications.
   </p>
 </section>
-<section data-model="org.1edtech.ob.v3p0.model" data-package="SharedOAuth" title="OAuth 2.0 Vocabularies">
+<section data-model="org.1edtech.ob.v3p0.model" data-package="SharedOAuth" title="Shared OAuth 2.0 Models">
   <p>
     The data models in this section are shared by all IMS service specifications.
   </p>
 </section>
-<section data-model="org.1edtech.ob.v3p0.model" data-package="ProofModels" title="VC-JWT Data Models">
+<section data-model="org.1edtech.ob.v3p0.model" data-package="ProofModels" title="Shared Proof Models">
   <p>
     Data models for the JSON Web Token Proof Format (VC-JWT) [[VC-DATA-MODEL]] shared by [[[OB-30]]] and [[[CLR-20]]].
   </p>

--- a/ob_v3p0/integrity.md
+++ b/ob_v3p0/integrity.md
@@ -12,12 +12,7 @@ The proof formats included in this specification fall into two categories:
 - Linked Data Proofs - The credential or presentation is signed and the signature is used to form a <a href="#proof">Proof</a> object which is appended to the credential or presentation. This format supports many different proof types. These are called embedded proofs because the proof is embedded in the data.
 
 <div class="note">
-  <p>
-    When this specification was published, no Linked Data Proof specification had been approved by a standards organization. Therefore this specification does not require any Linked Data Proof for conformance. When a Linked Data Proof specification is approved by a standards body, IMS may update this specification and conformance requirements.
-  </p>
-  <p>
-    The [=issuer=] or [=holder=] MAY use multiple proofs, but one MUST be a JSON Web Token Proof. If multiple proofs are provided, the [=verifier=] SHOULD process the JSON Web Token Proof first. If multiple Linked Data Proofs are provided, the [=verifier=] MAY use any one proof to verify the data.
-  </p>
+    The [=issuer=] or [=holder=] MAY use multiple proofs. If multiple proofs are provided, the [=verifier=] MAY use any one proof to verify the credential.
 </div>
 
 A third category of proof format called Non-Signature Proof is not covered by this specification. This category includes proofs such as proof of work.
@@ -268,7 +263,7 @@ Verifiers that receive an VerifiableCredential or VerifiablePresentation in Comp
 1. If the JSON object has a <code>vc</code> claim, convert the value of <code>vc</code> to an <a href="#assertioncredential">AssertionCredential</a> and continue with [[[#jwt-verify-credential]]].
 1. If the JSON object has a <code>vp</code> claim, convert the value of <code>vp</code> to a <a href="#presentationjwspayload">PresentationJwsPayload</a> and continue with [[[#jwt-verify-presentation]]].
 
-##### Verify a Credential {#jwt-verify-credential}
+##### Verify a Credential VC-JWT Signature {#jwt-verify-credential}
 
 - The JSON object MUST have the <code>iss</code> claim, and the value MUST match the <code>id</code> of the <code>issuer</code> of the <a href="#assertioncredential">AssertionCredential</a> object. If they do not match, the credential is not valid.
 - The JSON object MUST have the <code>sub</code> claim, and the value MUST match the <code>id</code> of the <code>credentialSubject</code> of the <a href="#assertioncredential">AssertionCredential</a> object. If they do not match, the credential is not valid.
@@ -279,17 +274,32 @@ Verifiers that receive an VerifiableCredential or VerifiablePresentation in Comp
 - <div class="issue" title="Use credentialStatus to determine if the credential has been revoked"></div>
 - <div class="issue" title="Should nested assertions be verified?"></div>
 
-##### Verify a Presentation {#jwt-verify-presentation}
+##### Verify a Presentation VC-JWT Signature {#jwt-verify-presentation}
 
 - The JSON object MUST have the <code>iss</code> claim, and the value MUST match the <code>id</code> of the <code>holder</code> of the <a href="#presentationjwspayload">PresentationJwsPayload</a> object. If they do not match, the presentation is not valid.
 - The JSON object MUST have the <code>nbf</code> claim, and the <a href="#numericdate">NumericDate</a> value MUST be converted to a <a href="#datetime">DateTime</a>, and MUST equal the <code>issuanceDate</code> of the <a href="#presentationjwspayload">PresentationJwsPayload</a> object. If they do not match or if the <code>issuanceDate</code> has not yet occurred, the presentation is not valid.
 - The JSON object MUST have the <code>jti</code> claim, and the value MUST match the <code>id</code> of the <a href="#presentationjwspayload">PresentationJwsPayload</a> object. If they do not match, the presentation is not valid.
 - If the JSON object has the <code>exp</code> claim, the <a href="#numericdate">NumericDate</a> MUST be converted to a <a href="#datetime">DateTime</a>, and MUST be used to set the value of the <code>expirationDate</code> of the <a href="#presentationjwspayload">PresentationJwsPayload</a> object. If the presentation has expired, the presentation is not valid.
-- <div class="issue" title="Verify the schema"></div>
-- <div class="issue" title="Should nested credentials be verified?">
-      <p>Should the nested credentials (assertion credentials) be verified when the presentation is verified?</p>
-      <p>If a nested credential is not valid, does that make the presentation invalid?</p>
-  </div>
+
+### Linked Data Proof Format {#lds-proof}
+
+This standard supports the Linked Data Proof format using the [[[LDS-ED25519-2020]]] suite.
+
+<div class="note">
+  Whenever possible, you should use a library or service to create and verify a Linked Data Proof. For example, Digital Bazaar, Inc. has a GitHub project that implements the [[[LDS-ED25519-2020]]] suite at <a href="https://github.com/digitalbazaar/ed25519-signature-2020">https://github.com/digitalbazaar/ed25519-signature-2020</a>.
+</div>
+
+#### Create the Proof
+
+Perform these steps to attach a Linked Data Proof to the credential or presentation:
+
+1. Create an instance of [Ed25519VerificationKey2020](#ed25519verificationkey2020) as shown in [Section 3.1.1 Ed25519VerificationKey2020](https://w3c-ccg.github.io/lds-ed25519-2020/#ed25519verificationkey2020) of [[LDS-ED25519-2020]].
+1. Using the key material, sign the credential or presentation object as shown in [Section 7.1 Proof Algothim](https://w3c-ccg.github.io/data-integrity-spec/#proof-algorithm) of [[DATA-INTEGRITY-SPEC]] to produce a [Proof](#proof) as shown in [Section 3.2.1 Ed25519 Signature 2020](https://w3c-ccg.github.io/lds-ed25519-2020/#ed25519-signature-2020) with a <code>proofPurpose</code> of "assertionMethod".
+1. Add the resulting proof object to the credential's or presentation's <code>proof</code> property.
+
+#### Verify a CLR Credential or Presentation Linked Data Signature {#lds-verify}
+
+Verify the Linked Data Proof signature as shown in [Section 7.2 Proof Verification Algorthim](https://w3c-ccg.github.io/data-integrity-spec/#proof-verification-algorithm) of [[DATA-INTEGRITY-SPEC]].
 
 ### Key Management
 

--- a/ob_v3p0/ob_v3p0.html
+++ b/ob_v3p0/ob_v3p0.html
@@ -80,16 +80,20 @@
     <script class="transclude" data-id="gettingstarted" src="gettingstarted.md"></script>
   </section>
 
-  <section data-format="markdown">
+  <section class="normative" data-format="markdown">
     <script class="transclude" data-id="docformat" src="docformat.md"></script>
   </section>
 
   <script class="transclude" data-id="api" src="api.html"></script>
 
   <script class="transclude" data-id="security" src="security.html"></script>
-  
+
   <section class="normative" data-format="markdown">
     <script class="transclude" data-id="integrity" src="integrity.md"></script>
+  </section>
+
+  <section class="normative" data-format="markdown">
+    <script class="transclude" data-id="verification" src="verification.md"></script>
   </section>
 
   <script class="transclude" data-id="vc_extensions" src="vc-extensions.html"></script>

--- a/ob_v3p0/respec-support/local-biblio.js
+++ b/ob_v3p0/respec-support/local-biblio.js
@@ -143,4 +143,14 @@ var _localBiblio = {
     "status": "Draft Community Group Report",
     "publisher": "W3C Credentials Community Group"
   },
+  "MULTIBASE": {
+    "title": "The Multibase Data Format",
+    "href": "https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-01",
+    "status": "Internet-Draft",
+    "publisher": "IETF"
+  },
+  "MULTICODEC": {
+    "title": "MULTICODEC",
+    "href": "https://github.com/multiformats/multicodec/"
+  },
 };

--- a/ob_v3p0/respec-support/local-biblio.js
+++ b/ob_v3p0/respec-support/local-biblio.js
@@ -137,4 +137,10 @@ var _localBiblio = {
     "status": "IMS Base Document",
     "publisher": "IMS Global Learning Consortium"
   },
+  "LDS-ED25519-2020": {
+    "title": "Ed25519 Signature 2020",
+    "href": "https://w3c-ccg.github.io/lds-ed25519-2020/",
+    "status": "Draft Community Group Report",
+    "publisher": "W3C Credentials Community Group"
+  },
 };

--- a/ob_v3p0/respec-support/local-biblio.js
+++ b/ob_v3p0/respec-support/local-biblio.js
@@ -112,5 +112,29 @@ var _localBiblio = {
         "href": "https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-02",
         "status": "Internet-Draft",
         "publisher": "Internet Engineering Task Force"
-    }
+  },
+  "DATA-INTEGRITY-SPEC": {
+    "title": "Data Integrity",
+    "href": "https://w3c-ccg.github.io/data-integrity-spec/",
+    "status": "CG-DRAFT",
+    "publisher": "Credentials Community Group"
+  },
+  "RL-10": {
+    "title": "IMS Revocation List Status Method",
+    "href": "https://imsglobal.org/spec/rl/v1p0/",
+    "status": "IMS Base Document",
+    "publisher": "IMS Global Learning Consortium"
+  },
+  "CR-10": {
+    "title": "IMS Credential Refresh Service",
+    "href": "https://imsglobal.org/spec/cr/v1p0/",
+    "status": "IMS Base Document",
+    "publisher": "IMS Global Learning Consortium"
+  },
+  "CS-10": {
+    "title": "IMS JSON Schema Validator 2019",
+    "href": "https://imsglobal.org/spec/cs/v1p0/",
+    "status": "IMS Base Document",
+    "publisher": "IMS Global Learning Consortium"
+  },
 };

--- a/ob_v3p0/vc-extensions.html
+++ b/ob_v3p0/vc-extensions.html
@@ -1,114 +1,25 @@
 var vc_extensions = `
 
-<section>
+<section class="normative">
   <h2 id="vc-extensions">Verifiable Credentials Extensions</h2>
 
   <p>
-    The [[[VC-DATA-MODEL]]] standard defines several types of extensions to enable "permissionless innovation". Some of
-    the extensions are tracked in the [[[VC-EXTENSION-REGISTRY]]]. VC extensions fall into 6 categories:
+    The [[[VC-DATA-MODEL]]] standard defines several types of extensions to enable "permissionless innovation".
+    Conformant extensions are tracked in the [[[VC-EXTENSION-REGISTRY]]].
+  </p>
+  <p>
+    This standard references four VC Extensions:
   </p>
   <ul>
-    <li>Proof Methods</li>
-    <li>Status Methods</li>
-    <li>Data Schema Validation Methods</li>
-    <li>Refresh Methods</li>
-    <li>Terms of Use Methods</li>
-    <li>Evidence Methods</li>
+    <li>A Proof Method called [[[LDS-ED25519-2020]]]</li>
+    <li>A Status Method called [[[RL-10]]]</li>
+    <li>A Refresh Method called [[[CR-10]]]</li>
+    <li>A Data Schema Validation Method called [[[CS-10]]]</li>
   </ul>
-  <p>
-    This standard defines three VC extensions: a Status Method <a href="#status-extension">RevocationList</a>, a
-    Refresh Method <a href="#refresh-extension">CredentialRefresh</a>, and a Data Schema Validation Method called
-    <a href="#schema-extension">JsonSchemaValidator2019</a>. Future versions of this specification may define
-    additional extensions.
-  </p>
   <div class="note">
-    These extensions are designed to work with any [=verifiable credential=] and may be contributed to the
+    The IMS extensions are designed to work with any [=verifiable credential=] and may be contributed to the
     [[VC-EXTENSION-REGISTRY]] in the future.
   </div>
-
-  <section>
-    <h3 id="status-extension">RevocationList</h3>
-    <p>
-      The "RevocationList" Status Method is used by a [=verifier=] to determine if the [=verifiable credential=] has
-      been revoked. Or if a previously revoked credential has been reinstated. This extension provides one of the
-      benefits of Hosted Verification in [[OB-20]].
-    </p>
-
-    <h4>Determine if a Credential is Revoked</h4>
-    <p>
-      If the <code>credentialStatus</code> property is present, and the <code>type</code> of the
-      <a href="#credentialstatus">CredentialStatus</a> object is "RevocationList", the [=verifier=] SHOULD
-      follow these steps:
-    </p>
-    <ol>
-      <li>
-        Fetch the <a href="#revocationlist">RevocationList</a> from the <code>id</code> of the
-        <a href="#credentialstatus">CredentialStatus</a> object.
-      </li>
-      <li>
-        If the <code>id</code> of the credential being verified appears in the list of <code>revokedCredentials</code>
-        and the corresponding <code>revoked</code> property is <code>true</code> or ommitted, then the credential has
-        been revoked by the issuer.
-      </li>
-    </ol>
-  </section>
-
-  <section>
-    <h3 id="refresh-extension">CredentialRefresh</h3>
-
-    <p>
-      The "CredentialRefresh" Refresh Method is used by a [=verifier=] to retrieve the current version of a [=verifiable
-      credential=]. This extension provides one of the benefits of Hosted Verification in [[OB-20]].
-    </p>
-
-    <h4>Refresh a Credential</h4>
-    <p>
-      If the <code>credentialRefresh</code> property is present, and the <code>type</code> of the
-      <a href="#credentialrefresh">CredentialRefresh</a> object is "CredentialRefresh", the [=verifier=] SHOULD
-      follow these steps:
-    </p>
-    <ol>
-      <li>
-        Fetch the [=verifiable credential=] from the <code>id</code> of the
-        <a href="#credentialrefresh">CredentialRefresh</a> object.
-      </li>
-      <li>
-        Update the credential in hand with the fetched credential.
-      </li>
-    </ol>
-  </section>
-
-  <section>
-    <h3 id="schema-extension">JsonSchemaValidator2019</h3>
-
-    <p>
-      The "JsonSchemaValidator2019" Data Schema Validation Method points to a [[JSON-SCHEMA-2019-09]] file that can be
-      used by a [=verifier=] to determine if the [=verifiable credential=] is well formed. This extension is used to
-      complete the "data validation" step described in [[[#verification]]].
-    </p>
-
-    <h4>Validate a Credential's JSON Schema</h4>
-    <p>
-      If the <code>credentialSchema</code> property is present, and the <code>type</code> of the
-      <a href="#credentialschema">CredentialSchema</a> object is "JsonSchemaValidator2019", the [=verifier=] SHOULD
-      follow these steps:
-    </p>
-    <ol>
-      <li>
-        Fetch the [[JSON-SCHEMA-2019-09]] file from the <code>id</code> of the <a
-          href="#credentialschema">CredentialSchema</a> object.
-      </li>
-      <li>
-        <a href="#serialization">Serialize</a> the credential into a JSON string.
-      </li>
-      <li>
-        Use a JSON Schema Validator compatible with [[JSON-SCHEMA-VALIDATION-2019-09]] (home grown or off-the-shelf)
-        to validate the credential's serialized JSON string.
-      </li>
-    </ol>
-
-  </section>
-
 </section>
 
 `;

--- a/ob_v3p0/verification.md
+++ b/ob_v3p0/verification.md
@@ -1,0 +1,18 @@
+var verification=`
+
+## Verification {#verification}
+
+[=Verification=] is the process to determine whether a [=verifiable credential=] or [=verifiable presentation=] is an authentic and timely statement of the issuer or presenter respectively. This includes checking that: the credential (or presentation) conforms to the specification; the proof method is satisfied; and, if present, the status check succeeds. Verification of a credential does not imply evaluation of the truth of claims encoded in the credential.
+
+The verification process in this standard is very similar to the [SignedBadge Verification](https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/index.html#SignedBadge) process in [[[OB-20]]].
+
+1. If the credential or presentation is signed using the [[[#jwt-proof]]] (VC-JWT), verify the signature as shown in [[[#jwt-verify]]]. If the credential or presentation is signed using an embedded proof, verify the signature as shown in [[[#lds-verify]]].
+   <div class="note">
+    The credential or presentation may have a VC-JWT proof and one or more Linked Data proofs. In this case, the Linked Data proofs will be attached to the credential in the <code>vc</code> or presentation in the <code>vp</code> claim of the signed JWT Payload. You may accept any one proof for verification. You do not need to verify all the signatures.
+   </div>
+1. If the <code>refreshService</code> property is present, and the <code>type</code> of the <a href="#refreshservice">RefreshService</a> object is "ImsCredentialRefresh", refresh the credential as shown in [[[CR-10]]] and then repeat step 1.
+1. If the <code>credentialStatus</code> property is present, and the <code>type</code> of the <a href="#credentialstatus">CredentialStatus</a> object is "ImsRevocationList", determine if the credential has been revoked as shown in [[[RL-10]]].
+1. If the <code>credentialSchema</code> property is present, and the <code>type</code> of the <a href="#credentialschema">CredentialSchema</a> object is "JsonSchemaValidator2019", perform data validation as shown in [[[CS-10]]].
+1. If all the above steps pass, the credential or presentation may be treated as valid.
+
+`;


### PR DESCRIPTION
This PR adds endorsement endpoints to the BadgeConnect API:

- getAssertions is modified to include endorsements of the credentials, achievements, and profiles included in the response.
- getEndorsements is added to retrieve the endorsement for a specific credential, achievement, or profile.
- postEndorsement is added to create or update an endorsement on a resource server.

Endorsements are also credentials, but endorsements of endorsements is not proposed.

Closes #338 
Alternative to PR #398 