### PR TITLE
Move evidence from CredentialSubject to Credential

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -7,13 +7,13 @@ Package Credentials DataModel
         Property id URI 1                                           "Unambiguous reference to the credential. Required so it can be the subject of an endorsement."
         Property type IRI 1..*                                      "The value of the type property MUST be an unordered set. One of the items MUST be the URI 'VerifiableCredential', and one of the items MUST be the URI 'AssertionCredential'."
         Property credentialSubject AssertionSubject 1               "The recipient of the achievement."
+        Property evidence Evidence 0..*                             "A description of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible."
         Mixin Extensions
 
     Class AssertionSubject Unordered false [CredentialSubject]      "A collection of information about the recipient of an achievement. Maps to Credential Subject in [[VC-DATA-MODEL]]."
         Property id URI 0..1                                        "An identifier for the Credential Subject. Either `id` or `recipient` or both is required."
         Property recipient IdentityObject 0..1                      "The recipient of the achievement. Either `id` or `recipient` or both is required."
         Property achievement Achievement 0..1                       "The achievement being awarded."
-        Property evidence Evidence 0..*                             "A description of the work that the recipient did to earn the achievement. This can be a page that links out to other pages if linking directly to the work is infeasible."
         Property image Image 0..1                                   "An image representing this user's achievement. If present, this must be a PNG or SVG image, and should be prepared via the 'baking' instructions. An 'unbaked' image for the achievement is defined in the Achievement class and should not be duplicated here."
         Property narrative Markdown 0..1                            "A narrative that connects multiple pieces of evidence. Likely only present at this location if evidence is a multi-value array."
         Property results Result 0..*                                "The set of results being asserted."


### PR DESCRIPTION
VC Data Model 1.1 defines [Evidence](https://www.w3.org/TR/vc-data-model/#evidence) as
> The value of the evidence [property](https://www.w3.org/TR/vc-data-model/#dfn-property) MUST be one or more evidence schemes providing enough information for a [verifier](https://www.w3.org/TR/vc-data-model/#dfn-verifier) to determine whether the evidence gathered by the [issuer](https://www.w3.org/TR/vc-data-model/#dfn-issuers) meets its confidence requirements for relying on the [credential](https://www.w3.org/TR/vc-data-model/#dfn-credential). Each evidence scheme is identified by its [type](https://www.w3.org/TR/vc-data-model/#dfn-type). The id [property](https://www.w3.org/TR/vc-data-model/#dfn-property) is optional, but if present, SHOULD contain a URL that points to where more information about this instance of evidence can be found. The precise content of each evidence scheme is determined by the specific evidence [type](https://www.w3.org/TR/vc-data-model/#dfn-type) definition.

This is compatible with the OB definition of evidence (probably because OB took cues from early VC work).

And in VC Data Model 1.1 `evidence` is a property of the Credential (not the CredentialSubject where I put it when mapping OB 2.0 Assertion properties to VC).

This PR moves the `evidence` property from the credential subject class to the credential class.

NOTE: There is more discussion in #344 

Closes #344 
