### PR TITLE
Rename assertion credential

### DIFF
--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -396,11 +396,11 @@ var api = `
     <!-- postAssertion -->
     <section>
       <h3 id="postassertion">postAssertion</h3>
-      <p>Create or update an AssertionCredential on the [=resource server=].</p>
+      <p>Create or update an OpenBadgeCredential on the [=resource server=].</p>
       <p>
-        If the [=resource server=] is holding an AssertionCredential with the same <code>id</code>, it will be updated.
+        If the [=resource server=] is holding an OpenBadgeCredential with the same <code>id</code>, it will be updated.
         Otherwise
-        the [=resource server=] will store the AssertionCredential in the request payload as a resource.
+        the [=resource server=] will store the OpenBadgeCredential in the request payload as a resource.
       </p>
 
       <h4 id="postassertion-request">Request Format</h4>
@@ -478,7 +478,7 @@ var api = `
           <tr>
             <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
             <td>
-              The AssertionCredential to be updated or created on the [=resource server=]. The AssertionCredential
+              The OpenBadgeCredential to be updated or created on the [=resource server=]. The OpenBadgeCredential
               MUST be signed with [[[#jwt-proof]]].
             </td>
             <td>Required</td>
@@ -495,7 +495,7 @@ var api = `
           Accept: text/plain
           Content-Type: text/plain
 
-          // The AssertionCredential in Compact JWS format
+          // The OpenBadgeCredential in Compact JWS format
           header.payload.signature
         </pre>
 
@@ -515,8 +515,8 @@ var api = `
             <td>200</td>
             <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
             <td>
-              &#39;OK&#39; - The AssertionCredential was successfully updated. The response payload MUST be the
-              AssertionCredential that
+              &#39;OK&#39; - The OpenBadgeCredential was successfully updated. The response payload MUST be the
+              OpenBadgeCredential that
               was posted.
             </td>
             <td>Required</td>
@@ -525,8 +525,8 @@ var api = `
             <td>201</td>
             <td><a href="#org.1edtech.ob.v3p0.derived.compactjws.class">CompactJws</a></td>
             <td>
-              &#39;Created&#39; - The AssertionCredential was successfully created. The response payload MUST be the
-              AssertionCredential
+              &#39;Created&#39; - The OpenBadgeCredential was successfully created. The response payload MUST be the
+              OpenBadgeCredential
               that was posted.
             </td>
             <td>Required</td>
@@ -606,7 +606,7 @@ var api = `
         HTTP/1.1 200 OK
         Content-Type: text/plain
 
-        // The AssertionCredential in Compact JWS format
+        // The OpenBadgeCredential in Compact JWS format
         header.payload.signature
       </pre>
     </section>

--- a/ob_v3p0/certification.md
+++ b/ob_v3p0/certification.md
@@ -31,7 +31,7 @@ After IMS reviews your submitted information and notifies you that your applicat
 
 ### Open Badges 3.0 Issuer Service Conformance {#issuer-conformance}
 
-A Open Badges **Issuer** is an application that allows for the creation of <a href="#achievement">Achievements</a> and the subsequent delivery of <a href="#assertioncredential">AssertionCredentials</a> to recipients that conform to the Open Badges Specification. The candidate platform must issue a valid baked badge and demonstrate how the badge is retrieved by the recipient. The candidate platform must also meet Service Consumer (Write) requirements and can send an AssertionCredential or a Profile to a product that conforms to Service Provider (Write) requirements.
+A Open Badges **Issuer** is an application that allows for the creation of <a href="#achievement">Achievements</a> and the subsequent delivery of <a href="#openbadgecredential">OpenBadgeCredentials</a> to recipients that conform to the Open Badges Specification. The candidate platform must issue a valid baked badge and demonstrate how the badge is retrieved by the recipient. The candidate platform must also meet Service Consumer (Write) requirements and can send an OpenBadgeCredential or a Profile to a product that conforms to Service Provider (Write) requirements.
 
 #### Tests {#issuer-tests}
 
@@ -51,11 +51,11 @@ An Open Badges Displayer is an application that displays and verifies badges for
 
 ### Open Badges 3.0 Host Service Conformance {#host-conformance}
 
-An Open Badges **Host** is an application that can aggregate and publicly host Assertions for recipients. It also supports export of badges at user request. The candidate platform must be able to import all formats of Open Badges as well as prove that badge metadata is not lost upon export of the badge. The candidate platform must also meet [[[#service-provider-write]]] requirements and accept an AssertionCredential or a Profile from an Issuer application. And meet [[[#service-consumer-read]]] and [[[#service-provider-read]]] requirements for exchanging AssertionCredentials with other Host applications.
+An Open Badges **Host** is an application that can aggregate and publicly host Assertions for recipients. It also supports export of badges at user request. The candidate platform must be able to import all formats of Open Badges as well as prove that badge metadata is not lost upon export of the badge. The candidate platform must also meet [[[#service-provider-write]]] requirements and accept an OpenBadgeCredential or a Profile from an Issuer application. And meet [[[#service-consumer-read]]] and [[[#service-provider-read]]] requirements for exchanging AssertionCredentials with other Host applications.
 
 #### Tests {#tests-host}
 
-1. Import each of the provided artifacts (baked PNG badge, baked SVG badge, and AssertionCredential URL), verify the badge, and submit the status to the conformance test system.
+1. Import each of the provided artifacts (baked PNG badge, baked SVG badge, and OpenBadgeCredential URL), verify the badge, and submit the status to the conformance test system.
 1. Export the imported badge and submit the exported badge to the conformance test system.
 1. Complete [[[#service-provider-write]]].
 1. Complete [[[#service-consumer-read]]].

--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -2,14 +2,14 @@
 
 Package Credentials DataModel
 
-    Class AssertionCredential Unordered false [VerifiableCredential] "AssertionCredentials are representations of an awarded achievement, used to share information about a achievement belonging to one earner. Maps to a Verifiable Credential as defined in the [[VC-DATA-MODEL]]."
+    Class OpenBadgeCredential Unordered false [VerifiableCredential] "OpenBadgeCredentials are representations of an awarded achievement, used to share information about an achievement belonging to one earner. Maps to a Verifiable Credential as defined in the [[VC-DATA-MODEL]]."
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value 'https://www.w3.org/2018/credentials/v1', and the second item is a URI with the value 'https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld'."
         Property id URI 1                                           "Unambiguous reference to the credential. Required so it can be the subject of an endorsement."
-        Property type IRI 1..*                                      "The value of the type property MUST be an unordered set. One of the items MUST be the URI 'VerifiableCredential', and one of the items MUST be the URI 'AssertionCredential'."
-        Property credentialSubject AssertionSubject 1               "The recipient of the achievement."
+        Property type IRI 1..*                                      "The value of the type property MUST be an unordered set. One of the items MUST be 'VerifiableCredential', and one of the items MUST be either 'OpenBadgeCredential' or 'AchievementCredential`. 'AchievementCrendential' is an alias for 'OpenBadgeCredential'."
+        Property credentialSubject OpenBadgeSubject 1               "The recipient of the achievement."
         Mixin Extensions
 
-    Class AssertionSubject Unordered false [CredentialSubject]      "A collection of information about the recipient of an achievement. Maps to Credential Subject in [[VC-DATA-MODEL]]."
+    Class OpenBadgeSubject Unordered false [CredentialSubject]      "A collection of information about the recipient of an achievement. Maps to Credential Subject in [[VC-DATA-MODEL]]."
         Property id URI 0..1                                        "An identifier for the Credential Subject. Either `id` or `recipient` or both is required."
         Property recipient IdentityObject 0..1                      "The recipient of the achievement. Either `id` or `recipient` or both is required."
         Property achievement Achievement 0..1                       "The achievement being awarded."

--- a/ob_v3p0/datamodel.html
+++ b/ob_v3p0/datamodel.html
@@ -4,16 +4,16 @@ var datamodel = `
   <p>
     The data models in this section are shared by [[[OB-30]]] and [[[CLR-20]]].
   </p>
-  <section data-class="org.1edtech.ob.v3p0.assertioncredential.class">
-    <pre class="json example vc" data-schema="org.1edtech.ob.v3p0.assertioncredential.class"
-      title="Sample AssertionCredential" data-vc-vm="https://example.edu/issuers/565049#key-1">
+  <section data-class="org.1edtech.ob.v3p0.openbadgecredential.class">
+    <pre class="json example vc" data-schema="org.1edtech.ob.v3p0.openbadgecredential.class"
+      title="Sample OpenBadgeCredential" data-vc-vm="https://example.edu/issuers/565049#key-1">
       {
         "@context": [
           "https://www.w3.org/2018/credentials/v1",
           "https://imsglobal.github.io/openbadges-specification/context.json"
         ],
         "id": "http://example.edu/credentials/3732",
-        "type": ["VerifiableCredential", "AssertionCredential"],
+        "type": ["VerifiableCredential", "OpenBadgeCredential"],
         "issuer": {
           "id": "https://example.edu/issuers/565049",
           "name": "Example University"
@@ -23,13 +23,13 @@ var datamodel = `
           "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
         },
         "credentialSchema": [{
-          "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.assertioncredential.class",
+          "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.openbadgecredential.class",
           "type": "JsonSchemaValidator2019"
         }]
       }
     </pre>
   </section>
-  <section data-class="org.1edtech.ob.v3p0.assertionsubject.class"></section>
+  <section data-class="org.1edtech.ob.v3p0.openbadgesubject.class"></section>
   <section data-class="org.1edtech.ob.v3p0.achievement.class"></section>
 </section>
 <section data-model="org.1edtech.ob.v3p0.model" data-package="SharedApi" title="Shared API Data Models">

--- a/ob_v3p0/docformat.md
+++ b/ob_v3p0/docformat.md
@@ -2,14 +2,14 @@ var docformat = `
 
 ## Open Badges Document Formats {#docformat}
 
-[AssertionCredentials](#org.1edtech.ob.v3p0.assertioncredential.class) can be exchanged as documents as defined in this section, or by using the [Open Badges API](#api). Documents can be exchanged as a text file, a web resource, or embedded in an image. The contents of an Open Badge document MUST meet the following criteria:
+[AssertionCredentials](#org.1edtech.ob.v3p0.openbadgecredential.class) can be exchanged as documents as defined in this section, or by using the [Open Badges API](#api). Documents can be exchanged as a text file, a web resource, or embedded in an image. The contents of an Open Badge document MUST meet the following criteria:
 
-- The contents of the file MUST represent exactly one [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class)
-- The [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class) MUST be serialized as JSON and JSON-LD (see [[[#serialization]]])
+- The contents of the file MUST represent exactly one [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class)
+- The [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class) MUST be serialized as JSON and JSON-LD (see [[[#serialization]]])
 - JSON exchanged between systems that are not part of a closed ecosystem MUST be encoded using UTF-8 [[RFC3629]].
 
-<pre class="json example vc" data-schema="org.1edtech.ob.v3p0.assertioncredential.class"
-      title="Sample AssertionCredential file contents"
+<pre class="json example vc" data-schema="org.1edtech.ob.v3p0.openbadgecredential.class"
+      title="Sample OpenBadgeCredential file contents"
       data-vc-vm="https://example.edu/issuers/565049#key-1">
   {
     "@context": [
@@ -17,7 +17,7 @@ var docformat = `
       "https://imsglobal.github.io/openbadges-specification/context.json"
     ],
     "id": "http://example.edu/credentials/3732",
-    "type": ["VerifiableCredential", "AssertionCredential"],
+    "type": ["VerifiableCredential", "OpenBadgeCredential"],
     "issuer": {
       "id": "https://example.edu/issuers/565049",
       "type": "Profile",
@@ -28,7 +28,7 @@ var docformat = `
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
     },
     "credentialSchema": [{
-      "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.assertioncredential.class",
+      "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.openbadgecredential.class",
       "type": "JsonSchemaValidator2019"
     }]
   }
@@ -36,21 +36,21 @@ var docformat = `
 
 ### File Format
 
-If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) the contents of the file MUST be the [=Compact JWS=] string formed as a result of signing the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class) with VC-JWT. The file extension SHOULD be ".jws" or ".jwt".
+If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) the contents of the file MUST be the [=Compact JWS=] string formed as a result of signing the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class) with VC-JWT. The file extension SHOULD be ".jws" or ".jwt".
 
-If an embedded proof method is used instead, the contents of the file MUST be the JSON representation of the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class). The file extension SHOULD be ".json".
+If an embedded proof method is used instead, the contents of the file MUST be the JSON representation of the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class). The file extension SHOULD be ".json".
 
 ### Web Resource
 
-If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) the contents of the response MUST be the [=Compact JWS=] string formed as a result of signing the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class) with VC-JWT. The <code>Content-Type</code> SHOULD be <code>text/plain</code>.
+If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) the contents of the response MUST be the [=Compact JWS=] string formed as a result of signing the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class) with VC-JWT. The <code>Content-Type</code> SHOULD be <code>text/plain</code>.
 
-If an embedded proof method is used instead, the contents of the response MUST be the JSON representation of the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class). The <code>Content-Type</code> SHOULD be <code>application/json</code> or <code>application/ld+json</code>.
+If an embedded proof method is used instead, the contents of the response MUST be the JSON representation of the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class). The <code>Content-Type</code> SHOULD be <code>application/json</code> or <code>application/ld+json</code>.
 
 ### Baked Badge
 
 AssertionCredentials may be exchanged as image files with the credential encoded (baked) within. This allows the credential to be portable wherever image files may be stored or displayed.
 
-"Baking" is the process of taking an [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class) and embedding it into the image, so that when a user displays the image on a page, software that is Open Badges aware can automatically extract that AssertionCredential data and perform the checks necessary to see if a person legitimately earned the achievement within the image. The image MUST be in either PNG [[PNG]] or SVG [[SVG11]] format in order to support baking.
+"Baking" is the process of taking an [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class) and embedding it into the image, so that when a user displays the image on a page, software that is Open Badges aware can automatically extract that OpenBadgeCredential data and perform the checks necessary to see if a person legitimately earned the achievement within the image. The image MUST be in either PNG [[PNG]] or SVG [[SVG11]] format in order to support baking.
 
 #### PNG
 
@@ -58,7 +58,7 @@ AssertionCredentials may be exchanged as image files with the credential encoded
 
 An <a href="http://www.w3.org/TR/PNG/#11iTXt"><code>iTXt</code> chunk</a> should be inserted into the PNG with **keyword** <code>openbadges</code>.
 
-If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) the text value of the chunk MUST be the [=Compact JWS=] string formed as a result of signing the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class) with VC-JWT. Compression MUST NOT be used.
+If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) the text value of the chunk MUST be the [=Compact JWS=] string formed as a result of signing the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class) with VC-JWT. Compression MUST NOT be used.
 
 <pre class="js example" title="An example of creating a chunk with VC-JWT proof (assuming an iTXt constructor)">
   var chunk = new iTXt({
@@ -71,7 +71,7 @@ If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) the text value o
   })
 </pre>
 
-If an embedded proof method is used instead, the text value of the chunk MUST be the JSON representation of the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class). Compression MUST NOT be used.
+If an embedded proof method is used instead, the text value of the chunk MUST be the JSON representation of the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class). Compression MUST NOT be used.
 
 <pre class="js example" title="An example of creating a chunk with embedded proof (assuming an iTXt constructor)">
   var chunk = new iTXt({
@@ -86,7 +86,7 @@ If an embedded proof method is used instead, the text value of the chunk MUST be
               "https://purl.imsglobal.org/spec/ob/v3p0/context"
             ],
             "id": "http://example.edu/credentials/3732",
-            "type": ["VerifiableCredential", "AssertionCredential"],
+            "type": ["VerifiableCredential", "OpenBadgeCredential"],
             "issuer": {
               "id": "https://example.edu/issuers/565049",
               "type": "IssuerProfile",
@@ -105,7 +105,7 @@ An iTXt chunk with the keyword <code>openbadges</code> MUST NOT appear in a PNG 
 
 ##### Extracting {#png-extracting}
 
-Parse the PNG datastream until the first <a href="http://www.w3.org/TR/PNG/#11iTXt"><code>iTXt</code> chunk</a> is found with the keyword <code>openbadges</code>. The rest of the stream can be safely discarded. The text portion of the iTXt will either be the JSON representation of a [[[#org.1edtech.ob.v3p0.assertioncredential.class]]] or the [=Compact JWS=] string that was the result of signing the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class) with [[[#jwt-proof]]].
+Parse the PNG datastream until the first <a href="http://www.w3.org/TR/PNG/#11iTXt"><code>iTXt</code> chunk</a> is found with the keyword <code>openbadges</code>. The rest of the stream can be safely discarded. The text portion of the iTXt will either be the JSON representation of a [[[#org.1edtech.ob.v3p0.openbadgecredential.class]]] or the [=Compact JWS=] string that was the result of signing the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class) with [[[#jwt-proof]]].
 
 #### SVG
 
@@ -113,7 +113,7 @@ Parse the PNG datastream until the first <a href="http://www.w3.org/TR/PNG/#11iT
 
 First, add an <code>xmlns:openbadges</code> attribute to the <code>&lt;svg></code> tag with the value "https://purl.imsglobal.org/ob/v3p0". Directly after the <code>&lt;svg></code> tag, add an <code>&lt;openbadges:credential></code> tag.
 
-If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) add a <code>verify</code> attribute to the <code>&lt;openbadges:credential></code> tag. The value of <code>verify</code> attribute MUST be the [=Compact JWS=] string formed as a result of signing the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class) with VC-JWT.
+If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) add a <code>verify</code> attribute to the <code>&lt;openbadges:credential></code> tag. The value of <code>verify</code> attribute MUST be the [=Compact JWS=] string formed as a result of signing the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class) with VC-JWT.
 
 <pre class="xml example" title="An example of a well baked SVG with VC-JWT proof">
   &lt;?xml version="1.0" encoding="UTF-8"?>
@@ -126,7 +126,7 @@ If the credential is signed using the [[[#jwt-proof]]] (VC-JWT) add a <code>veri
   &lt;/svg>
 </pre>
 
-If an embedded proof method is used instead, omit the <code>verify</code> attribute, and the JSON representation of the [AssertionCredential](#org.1edtech.ob.v3p0.assertioncredential.class) MUST go into the body of the tag, wrapped in <code>&lt;![CDATA[...]]></code>.
+If an embedded proof method is used instead, omit the <code>verify</code> attribute, and the JSON representation of the [OpenBadgeCredential](#org.1edtech.ob.v3p0.openbadgecredential.class) MUST go into the body of the tag, wrapped in <code>&lt;![CDATA[...]]></code>.
 
 <pre class="xml example" title="An example of a well baked SVG with embedded proof">
   &lt;?xml version="1.0" encoding="UTF-8"?>
@@ -141,7 +141,7 @@ If an embedded proof method is used instead, omit the <code>verify</code> attrib
             "https://purl.imsglobal.org/spec/ob/v3p0/context"
           ],
           "id": "http://example.edu/credentials/3732",
-          "type": ["VerifiableCredential", "AssertionCredential"],
+          "type": ["VerifiableCredential", "OpenBadgeCredential"],
           "issuer": {
             "id": "https://example.edu/issuers/565049",
             "type": "IssuerProfile",
@@ -160,7 +160,7 @@ If an embedded proof method is used instead, omit the <code>verify</code> attrib
   &lt;/svg>
 </pre>
 
-There MUST be only one <code>&lt;openbadges:credential></code> tag in an SVG. When baking an image that already contains AssertionCredential data, the implementor may choose whether to pass the user an error or overwrite the existing tag.
+There MUST be only one <code>&lt;openbadges:credential></code> tag in an SVG. When baking an image that already contains OpenBadgeCredential data, the implementor may choose whether to pass the user an error or overwrite the existing tag.
 
 ##### Extracting
 

--- a/ob_v3p0/examples.html
+++ b/ob_v3p0/examples.html
@@ -117,7 +117,7 @@
             "https://imsglobal.github.io/openbadges-specification/context.json"
           ],
           "id": "http://example.edu/credentials/3732",
-          "type": ["VerifiableCredential", "AssertionCredential"],
+          "type": ["VerifiableCredential", "OpenBadgeCredential"],
           "issuer": {
             "id": "https://example.edu/issuers/565049",
             "name": "Example University"
@@ -127,7 +127,7 @@
             "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
           },
           "credentialSchema": [{
-            "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.assertioncredential.class",
+            "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.openbadgecredential.class",
             "type": "JsonSchemaValidator2019"
           }]
         }
@@ -143,7 +143,7 @@
             "https://imsglobal.github.io/openbadges-specification/context.json"
           ],
           "id": "http://example.edu/credentials/3732",
-          "type": ["VerifiableCredential", "AssertionCredential"],
+          "type": ["VerifiableCredential", "OpenBadgeCredential"],
           "issuer": {
             "id": "https://example.edu/issuers/565049",
             "name": "Example University"
@@ -154,7 +154,7 @@
             "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
           },
           "credentialSchema": [{
-            "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.assertioncredential.class",
+            "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.openbadgecredential.class",
             "type": "JsonSchemaValidator2019"
           }]
         }
@@ -164,14 +164,14 @@
     <section>
       <h2 id="schema-validation">Sample with schema validation</h2>
       <pre class="example json"
-        data-schema="org.1edtech.ob.v3p0.assertioncredential.class">
+        data-schema="org.1edtech.ob.v3p0.openbadgecredential.class">
         {
           "@context": [
             "https://www.w3.org/2018/credentials/v1",
             "https://imsglobal.github.io/openbadges-specification/context.json"
           ],
           "id": "http://example.edu/credentials/3732",
-          "type": ["VerifiableCredential", "AssertionCredential"],
+          "type": ["VerifiableCredential", "OpenBadgeCredential"],
           "issuer": {
             "id": "https://example.edu/issuers/565049",
             "name": "Example University"
@@ -182,7 +182,7 @@
             "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
           },
           "credentialSchema": [{
-            "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.assertioncredential.class",
+            "id": "https://imsum2.herokuapp.com/jsonschema?classId=org.1edtech.ob.v3p0.openbadgecredential.class",
             "type": "JsonSchemaValidator2019"
           }]
         }

--- a/ob_v3p0/integrity.md
+++ b/ob_v3p0/integrity.md
@@ -47,7 +47,7 @@ The JOSE Header, JWT Payload, and JWS Signature are combined to form a Compact J
 
 The resulting [=JWS=] proves that the [=issuer=] or [=holder=] signed the [=JWT Payload=] turning the [=credential=] or [=presentation=] into a [=verifiable credential=] or [=verifiable presentation=].
 
-When using the JSON Web Token Proof Format, the <code>proof</code> property MAY be ommitted from the <a href="#assertioncredential">AssertionCredential</a> or <a href="#verifiablepresentation">VerifiablePresentation</a>. If a Linked Data Proof is also provided, it MUST be created before the JSON Web Token Proof Format is created.
+When using the JSON Web Token Proof Format, the <code>proof</code> property MAY be ommitted from the <a href="#openbadgecredential">OpenBadgeCredential</a> or <a href="#verifiablepresentation">VerifiablePresentation</a>. If a Linked Data Proof is also provided, it MUST be created before the JSON Web Token Proof Format is created.
 
 #### Create the JOSE Header {#joseheader}
 
@@ -145,7 +145,7 @@ The JSON Web Token Proof for each nested credential MUST be created prior to cre
 
 The JWT Payload is a JSON object with the following properties (JWT Claims). In addition to the standard JWT Claims [[RFC7519]], the [[[VC-DATA-MODEL]]] specification registered two new JWT Claim Names:
 
-- <code>vc</code>: A JSON object which contains the [=verifiable credential=] to be signed. In this specification, that credential MUST be an <a href="#assertioncredential">AssertionCredential</a> object.
+- <code>vc</code>: A JSON object which contains the [=verifiable credential=] to be signed. In this specification, that credential MUST be an <a href="#openbadgecredential">OpenBadgeCredential</a> object.
 - <code>vp</code>: A JSON object which contains the [=verifiable presentation=] to be signed. In this specification, that presentation MUST be a <a href="#presentationjwspayload">PresentationJwsPayload</a> object.
 
 Additional standard JWT Claims Names are allowed, but their relationship to the credential or presentation is not defined.
@@ -205,7 +205,7 @@ Additional standard JWT Claims Names are allowed, but their relationship to the 
     </tr>
     <tr>
       <td><code>vc</code></td>
-      <td><a href="#assertioncredential">AssertionCredential</a></td>
+      <td><a href="#openbadgecredential">OpenBadgeCredential</a></td>
       <td>
         The credential being signed. Omit if the payload is a presentation.
       </td>
@@ -260,16 +260,16 @@ Verifiers that receive an VerifiableCredential or VerifiablePresentation in Comp
      <p>IMS strongly recommends using an existing, stable library for this step.</p>
    </div>
 1. Base64url-decode the JWT Payload segment of the Compact JWS and parse it into a JSON object.
-1. If the JSON object has a <code>vc</code> claim, convert the value of <code>vc</code> to an <a href="#assertioncredential">AssertionCredential</a> and continue with [[[#jwt-verify-credential]]].
+1. If the JSON object has a <code>vc</code> claim, convert the value of <code>vc</code> to an <a href="#openbadgecredential">OpenBadgeCredential</a> and continue with [[[#jwt-verify-credential]]].
 1. If the JSON object has a <code>vp</code> claim, convert the value of <code>vp</code> to a <a href="#presentationjwspayload">PresentationJwsPayload</a> and continue with [[[#jwt-verify-presentation]]].
 
 ##### Verify a Credential VC-JWT Signature {#jwt-verify-credential}
 
-- The JSON object MUST have the <code>iss</code> claim, and the value MUST match the <code>id</code> of the <code>issuer</code> of the <a href="#assertioncredential">AssertionCredential</a> object. If they do not match, the credential is not valid.
-- The JSON object MUST have the <code>sub</code> claim, and the value MUST match the <code>id</code> of the <code>credentialSubject</code> of the <a href="#assertioncredential">AssertionCredential</a> object. If they do not match, the credential is not valid.
-- The JSON object MUST have the <code>nbf</code> claim, and the <a href="#numericdate">NumericDate</a> value MUST be converted to a <a href="#datetime">DateTime</a>, and MUST equal the <code>issuanceDate</code> of the <a href="#assertioncredential">AssertionCredential</a> object. If they do not match or if the <code>issuanceDate</code> has not yet occurred, the credential is not valid.
-- The JSON object MUST have the <code>jti</code> claim, and the value MUST match the <code>id</code> of the <a href="#assertioncredential">AssertionCredential</a> object. If they do not match, the credential is not valid.
-- If the JSON object has the <code>exp</code> claim, the <a href="#numericdate">NumericDate</a> MUST be converted to a <a href="#datetime">DateTime</a>, and MUST be used to set the value of the <code>expirationDate</code> of the <a href="#assertioncredential">AssertionCredential</a> object. If the credential has expired, the credential is not valid.
+- The JSON object MUST have the <code>iss</code> claim, and the value MUST match the <code>id</code> of the <code>issuer</code> of the <a href="#openbadgecredential">OpenBadgeCredential</a> object. If they do not match, the credential is not valid.
+- The JSON object MUST have the <code>sub</code> claim, and the value MUST match the <code>id</code> of the <code>credentialSubject</code> of the <a href="#openbadgecredential">OpenBadgeCredential</a> object. If they do not match, the credential is not valid.
+- The JSON object MUST have the <code>nbf</code> claim, and the <a href="#numericdate">NumericDate</a> value MUST be converted to a <a href="#datetime">DateTime</a>, and MUST equal the <code>issuanceDate</code> of the <a href="#openbadgecredential">OpenBadgeCredential</a> object. If they do not match or if the <code>issuanceDate</code> has not yet occurred, the credential is not valid.
+- The JSON object MUST have the <code>jti</code> claim, and the value MUST match the <code>id</code> of the <a href="#openbadgecredential">OpenBadgeCredential</a> object. If they do not match, the credential is not valid.
+- If the JSON object has the <code>exp</code> claim, the <a href="#numericdate">NumericDate</a> MUST be converted to a <a href="#datetime">DateTime</a>, and MUST be used to set the value of the <code>expirationDate</code> of the <a href="#openbadgecredential">OpenBadgeCredential</a> object. If the credential has expired, the credential is not valid.
 - <div class="issue" title="Verify the schema"></div>
 - <div class="issue" title="Use credentialStatus to determine if the credential has been revoked"></div>
 - <div class="issue" title="Should nested assertions be verified?"></div>

--- a/ob_v3p0/overview.md
+++ b/ob_v3p0/overview.md
@@ -10,7 +10,7 @@ These layers of cryptographic proof can provide security and privacy enhancement
 
 ### What does adopting Verifiable Credentials entail?
 
-This specification changes the structure of the Open Badges [Assertion](#assertioncredential) class, to adopt the conventions of the [[[VC-DATA-MODEL]]]. This means that badges issued under this specification will not be conformant to all of the existing 2.x data model requirements.
+This specification changes the structure of the Open Badges [OpenBadgeCredential](#openbadgecredential) class, to adopt the conventions of the [[[VC-DATA-MODEL]]]. This means that badges issued under this specification will not be conformant to all of the existing 2.x data model requirements.
 
 Previous versions of an Open Badges Assertion, illustrated in the graphic below, structures its objects like this:
 An Assertion identifies a recipient with a "recipient" relationship to an IdentityObject that contains identifying properties. It identifies which badge it represents with a "badge" relationship to a BadgeClass. It identifies its verification information with a "verification" relationship to a VerificationObject. It identifies its issuer with an "issuer" relationship between the BadgeClass and the Issuer.

--- a/ob_v3p0/readme.md
+++ b/ob_v3p0/readme.md
@@ -72,7 +72,7 @@ To load your local changes to [common_credentials.lines](common_credentials.line
 In addition to rendering a normative data model, the plugin can also validate examples against the JSON Schema for the example. Any schema errors will be displayed in the rendered example. You can request schema validation by decorating the example with a `data-schema` attribute where the value is the `id` of the class.
 
 ```html
-<pre class="json example" data-schema="org.1edtech.ob.v3p0.assertioncredential.class"
+<pre class="json example" data-schema="org.1edtech.ob.v3p0.openbadgecredential.class"
   title="Sample assertion credential">
   {
     "@context": [
@@ -81,7 +81,7 @@ In addition to rendering a normative data model, the plugin can also validate ex
       "https://imsglobal.github.io/openbadges-specification/context.json"
     ],
     "id": "http://example.edu/credentials/3732",
-    "type": ["VerifiableCredential", "AssertionCredential"],
+    "type": ["VerifiableCredential", "OpenBadgeCredential"],
     "issuer": {
       "id": "https://example.edu/issuers/565049",
       "type": "IssuerProfile",

--- a/ob_v3p0/serialization.md
+++ b/ob_v3p0/serialization.md
@@ -2,7 +2,7 @@ var serialization=`
 
 ## Serialization
 
-The data model as described in Appendix [[[#datamodels]]] is the canonical structural representation of an Open Badges [=verifiable credential=] ([AchievementCredential](#org.1edtech.ob.v3p0.assertioncredential.class)) and [=verifiable presentation=] ([VerifiablePresentation](#org.1edtech.ob.v3p0.verifiablepresentation.class)). All serializations are representations of that data model in a specific format. This section specifies how the data model is realized in JSON-LD and plain JSON.
+The data model as described in Appendix [[[#datamodels]]] is the canonical structural representation of an Open Badges [=verifiable credential=] ([AchievementCredential](#org.1edtech.ob.v3p0.openbadgecredential.class)) and [=verifiable presentation=] ([VerifiablePresentation](#org.1edtech.ob.v3p0.verifiablepresentation.class)). All serializations are representations of that data model in a specific format. This section specifies how the data model is realized in JSON-LD and plain JSON.
 
 ### JSON
 


### PR DESCRIPTION
OB project group discussed PR #385 on 4/14/22 and approved merge. This PR renames data models AssertionCredential and AssertionSubject to OpenBadgeCredential and OpenBadgeSubject throughout the OB 3.0 spec.