### PR TITLE
Reconcile Achievement class properties

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -20,15 +20,16 @@ Package Credentials DataModel
 
     Class Achievement Unordered false []                            "A collection of information about the accomplishment recognized by the Assertion. Many assertions may be created corresponding to one Achievement."
         Property id URI 1                                           "Unique URI for the Achievement. Required so the achievement can be the subject of an endorsement."
+        Property type IRI 1                                         "The type MUST be 'Achievement'".
         Property alignment Alignment 0..*                           "An object describing which objectives or educational standards this achievement aligns to, if any."
         Property achievementType AchievementType 0..1               "The type of achievement. This is an extensible vocabulary."
         Property creator Profile 0..1                               "The person or organization that created the achievement definition."
         Property creditsAvailable Float 0..1                        "Credit hours associated with this entity, or credit hours possible. For example 3.0."
-        Property criteria Criteria 0..1                             "Criteria document describing how to earn the achievement."
+        Property criteria Criteria 1                                "Criteria document describing how to earn the achievement."
         Property description String 1                               "A short description of the achievement."
         Property fieldOfStudy String 0..1                           "Category, subject, area of study, discipline, or general branch of knowledge. Examples include Business, Education, Psychology, and Technology."
         Property humanCode String 0..1                              "The code, generally human readable, associated with an achievement."
-        Property image Image 1                                      "The image representing the achievement."
+        Property image Image 0..1                                   "The image representing the achievement."
         Property level String 0..1                                  "Text that describes the level of achievement apart from how the achievement was performed or demonstrated. Examples would include 'Level 1', 'Level 2', 'Level 3'; or 'Bachelors', 'Masters', 'Doctoral'."
         Property name String 1                                      "The name of the achievement."
         Mixin OtherIdentifiers                                      // From CDM


### PR DESCRIPTION
Reconciles OB 2.0 and CLR 1.0 Achievement class properties.

In [OB 2.0](https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/index.html#BadgeClass), `id`, `type`, `name`, `description`, `image`, `criteria`, and `issuer` are required. And `type` is an array.

In [CLR 1.0](https://www.imsglobal.org/sites/default/files/spec/clr/v1p0/InfoModel/clr_InfoModel.html#Data_Achievement), only `id` and `name` are required. And `type` is not an array.

This PR

- Makes `id`, `type`, `criteria`, `description`, and `name` required properties
- Make `type` a single value (and that value must be "Achievement")
- Makes `image` and `creator` (replaces `issuer`...sort of) optional properties

Closes #342