### PR TITLE
Add AchievementSubject `type` property

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -16,6 +16,7 @@ Package Credentials DataModel
 
     Class AchievementSubject Unordered false [CredentialSubject]    "A collection of information about the recipient of an achievement. Maps to Credential Subject in [[VC-DATA-MODEL]]."
         Property id URI 0..1                                        "An identifier for the Credential Subject. Either `id` or at least one `identifier` MUST be supplied."
+        Property type IRI 1..*                                      "The value of the type property MUST be an unordered set. One of the items MUST be the IRI 'AchievementSubject'."
         Property identifier IdentityObject 0..*                     "Other identifiers for the recipient of the achievement. Either `id` or at least one `identifier` MUST be supplied."
         Property achievement Achievement 0..1                       "The achievement being awarded."
         Property image Image 0..1                                   "An image representing this user's achievement. If present, this must be a PNG or SVG image, and should be prepared via the 'baking' instructions. An 'unbaked' image for the achievement is defined in the Achievement class and should not be duplicated here."

--- a/ob_v3p0/datamodel.html
+++ b/ob_v3p0/datamodel.html
@@ -19,9 +19,20 @@ var datamodel = `
           "name": "Example University"
         },
         "issuanceDate": "2010-01-01T00:00:00Z",
-        "name": "Example University Degree",
+        "name": "Example University Degree for Example Student",
         "credentialSubject": {
-          "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"          
+          "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+          "type": ["AchievementSubject"],
+          "achievement": {
+            "id": "https://example.edu/achievements/degree",
+            "type": "Achievement",
+            "achievementType": "Degree",
+            "name": "Example University Degree",
+            "description": "Represents the completion of a degree program",
+            "criteria": {
+              "id": "https://example.edu/achievements/degree"
+            }
+          }          
         }
       }
     </pre>


### PR DESCRIPTION
OB context defines the terms that are allowed in the `credentialSubject`:

```
"AchievementSubject": {
      "@id": "https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#AchievementSubject",
      "@context": {
        "achievement": {
          "@id": "https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#Achievement"
        },
        "identifier": {
          "@id": "https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#Identifier"
        },
        "result": {
          "@id": "https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#Result"
        }
      }
    }
```

Data Integrity Proofs will not calculate a signature if they do not recognize a term. So `credentialSubject.type` must specify "AchievementSubject". And because OB 3.0 allows extensions, the `type` property should be an array so extension properties are also recognized.

This PR adds a `type` property to the `AchievementSubject` class data model, and improves the [sample OpenBadgeCredential](https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#example-sample-openbadgecredential).