### PR TITLE
Feature/rename methods

### DIFF
--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -91,10 +91,10 @@ var api = `
           </td>
         </tr>
         <tr>
-          <td><a href="#postcredential">postCredential</a></td>
+          <td><a href="#upsertcredential">upsertCredential</a></td>
           <td>
-            <code>https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.create</code> -
-            Permission to create OpenBadgeCredentials for the authenticated entity.
+            <code>https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.upsert</code> -
+            Permission to create or update OpenBadgeCredentials for the authenticated entity.
           </td>
         </tr>
         <tr>
@@ -138,8 +138,8 @@ var api = `
         }
       </pre>
     </section>
-    <section data-operation="org.1edtech.ob.v3p0.rest.postcredential.operation">
-      <pre class="http example" title="Sample postCredential Request">
+    <section data-operation="org.1edtech.ob.v3p0.rest.upsertcredential.operation">
+      <pre class="http example" title="Sample upsertCredential Request">
         POST /ims/ob/v3p0/credentials HTTP/1.1
         Host: example.edu
         Authorization: Bearer 863DF0B10F5D432EB2933C2A37CD3135A7BB7B07A68F65D92
@@ -148,7 +148,7 @@ var api = `
 
         header.payload.signature
       </pre>
-      <pre class="http example" title="Sample postCredential Response">
+      <pre class="http example" title="Sample upsertCredential Response">
         HTTP/1.1 200 OK
         Content-Type: text/plain
 

--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -105,7 +105,7 @@ var api = `
           </td>
         </tr>
         <tr>
-          <td><a href="#postprofile">postProfile</a></td>
+          <td><a href="#putprofile">putProfile</a></td>
           <td>
             <code>https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.update</code> -
             Permission to update the profile for the authenticated entity.
@@ -147,7 +147,7 @@ var api = `
         Content-Type: text/plain
 
         header.payload.signature
-      </pre>  
+      </pre>
       <pre class="http example" title="Sample postCredential Response">
         HTTP/1.1 200 OK
         Content-Type: text/plain
@@ -176,9 +176,9 @@ var api = `
         }
       </pre>
     </section>
-    <section data-operation="org.1edtech.ob.v3p0.rest.postprofile.operation">
-      <pre class="http example" title="Sample postProfile Request">
-        POST /ims/ob/v3p0/profile HTTP/1.1
+    <section data-operation="org.1edtech.ob.v3p0.rest.putprofile.operation">
+      <pre class="http example" title="Sample putProfile Request">
+        PUT /ims/ob/v3p0/profile HTTP/1.1
         Host: example.edu
         Authorization: Bearer 863DF0B10F5D432EB2933C2A37CD3135A7BB7B07A68F65D92
         Accept: application/json
@@ -191,7 +191,7 @@ var api = `
           "telephone": "111-222-3333"
         }
       </pre>
-      <pre class="http example" title="Sample postProfile Response">
+      <pre class="http example" title="Sample putProfile Response">
         {
           "@context": [
                "https://purl.imsglobal.org/spec/ob/v3p0/context.json"
@@ -217,7 +217,7 @@ var api = `
       <pre class="http example" title="Sample getServiceDescription response">
         HTTP/1.1 200 OK
         Content-Type: application/json
-        
+
         ...
         "components": {
             "securitySchemes": {
@@ -268,7 +268,7 @@ var api = `
       </pre>
     </section>
   </section>
-  
+
   <section id="paging">
     <h5>Paging</h5>
     <p>

--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -54,7 +54,7 @@ var api = `
       <dd>
         This is the [=server=] that has the protected resources ([=badges=]). Also called Provider in the [[[SEC-11]]].
       </dd>
-      <dt><dfn data-lt="Credential equality & comparison">Credential equality & comparison</dfn></dt>
+      <dt><dfn data-lt="Credential equality and comparison">Credential equality & comparison</dfn></dt>
       <dd>
         <div class="note">
           @@@TBD

--- a/ob_v3p0/api.html
+++ b/ob_v3p0/api.html
@@ -54,6 +54,12 @@ var api = `
       <dd>
         This is the [=server=] that has the protected resources ([=badges=]). Also called Provider in the [[[SEC-11]]].
       </dd>
+      <dt><dfn data-lt="Credential equality & comparison">Credential equality & comparison</dfn></dt>
+      <dd>
+        <div class="note">
+          @@@TBD
+          </div>
+      </dd>
     </dl>
     <p>
       The role of each component during Registration, Obtaining Tokens, and Authenticating with Tokens are described

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -39,7 +39,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Scopes [getProfileCcg, getProfileAcg]
 
         Operation putProfile POST /profile                         "Update the profile for the authenticate entity."
-            Body Profile 1 application/json                         "The request SHOULD only include profile identifier properties to be added to the profile, not any existing data. The [=resource server=] MAY respond with 400 BAD_REQUEST to reject data that is known immediately to not be acceptable by the platform, e.g. to reject a "telephone" property if the [=resource server=] cannot validate telephone numbers."
+            Body Profile 1 application/json                         "The request MUST include the entire Profile object. The [=resource server=] MAY respond with 400 BAD_REQUEST to reject data that is known immediately to not be acceptable by the platform, e.g. to reject a "telephone" property if the [=resource server=] cannot validate telephone numbers."
             Response 200
                 Body Profile 1 application/json                     "The matching profile. Successful request responses will be the same as GET Profile and may not include the patched values (as the [=resource server=] may be waiting for asynchronous processes to complete before accepting the value). The values may never become part of the published profile."
             Responses PutErrorResponses

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -38,7 +38,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Response 404 Imsx_StatusInfo 1                          "As defined in [[rfc9110]], indicating that the origin server did not find a current representation for the target resource or is not willing to disclose that one exists."
             Scopes [getProfileCcg, getProfileAcg]
 
-        Operation putProfile POST /profile                         "Update the profile for the authenticate entity."
+        Operation putProfile PUT /profile                         "Update the profile for the authenticate entity."
             Body Profile 1 application/json                         "The request MUST include the entire Profile object. The [=resource server=] MAY respond with 400 BAD_REQUEST to reject data that is known immediately to not be acceptable by the platform, e.g. to reject a "telephone" property if the [=resource server=] cannot validate telephone numbers."
             Response 200
                 Body Profile 1 application/json                     "The matching profile. Successful request responses will be the same as GET Profile and may not include the patched values (as the [=resource server=] may be waiting for asynchronous processes to complete before accepting the value). The values may never become part of the published profile."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -19,7 +19,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Responses GetErrorResponses
             Scopes [getCredentialsAcg, getCredentialsCcg]
 
-        Operation postCredential POST /credentials                  "Create or replace an AchievementCredential on the [=resource server=]."
+        Operation upsertCredential POST /credentials                "Create or replace an AchievementCredential on the [=resource server=]."
             Body AchievementCredential 1 application/json           "If the AchievementCredential is not signed with the VC-JWT Proof Format, the request body MUST be a AchievementCredential and the `Content-Type` MUST be `application/json`."
             Body CompactJws 1 text/plain                            "If the AchievementCredential is signed with the VC-JWT Proof Format, the request body MUST be a CompactJws string and the `Content-Type` MUST be `text/plain`."
             Response 200                                            "The AchievementCredential was successfully replaced on the [=resource server=]. The response body MUST be the AchievementCredential in the request."
@@ -29,7 +29,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
                 Body AchievementCredential 1 application/json       "If the AchievementCredential is not signed with the VC-JWT Proof Format, the response body MUST be a AchievementCredential and the `Content-Type` MUST be `application/json`."
                 Body CompactJws 1 text/plain                        "If the AchievementCredential is signed with the VC-JWT Proof Format, the response body MUST be a CompactJws string and the `Content-Type` MUST be `text/plain`."
             Responses PostErrorResponses
-            Scopes [postCredentialAcg, postCredentialCcg]
+            Scopes [upsertCredentialAcg, upsertCredentialCcg]
 
         Operation getProfile GET /profile                           "Fetch the profile from the [=resource server=] for the supplied access token. Profiles that are received MAY contain attributes that a Host SHOULD authenticate before using in practice."
             Response 200
@@ -93,13 +93,13 @@ Package ACGSecurity SecurityModel OAUTH2ACG
 	Url AuthURL provider.example.com/auth
 	Url RefreshURL provider.example.com/refresh
 	Scope getCredentialsAcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.readonly      "Permission to read ClrCredentials for the authenticated entity."
-    Scope postCredentialAcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.create        "Permission to create or update ClrCredentials for the authenticated entity."
+    Scope upsertCredentialAcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.upsert        "Permission to create or update ClrCredentials for the authenticated entity."
 	Scope getProfileAcg     https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.readonly         "Permission to read the profile for the authenticated entity."
     Scope putProfileAcg    https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.update 			"Permission to update the profile for the authenticated entity."
 
 Package CCGSecurity SecurityModel OAUTH2CCG
 	Url TokenURL provider.example.com/token
 	Scope getCredentialsCcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.readonly      "Permission to read ClrCredentials for the authenticated entity."
-    Scope postCredentialCcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.create        "Permission to create or update ClrCredentials for the authenticated entity."
+    Scope upsertCredentialCcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.upsert        "Permission to create or update ClrCredentials for the authenticated entity."
 	Scope getProfileCcg     https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.readonly         "Permission to read the profile for the authenticated entity."
     Scope putProfileCcg    https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.update 			"Permission to update the profile for the authenticated entity."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -42,7 +42,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Body Profile 1 application/json                         "The request MUST include the entire Profile object. The [=resource server=] MAY respond with 400 BAD_REQUEST to reject data that is known immediately to not be acceptable by the platform, e.g. to reject a "telephone" property if the [=resource server=] cannot validate telephone numbers."
             Response 200
                 Body Profile 1 application/json                     "The matching profile. Successful request responses will be the same as GET Profile and may not include the patched values (as the [=resource server=] may be waiting for asynchronous processes to complete before accepting the value). The values may never become part of the published profile."
-            Response 202                                            "As defined in [[rfc9110]], indicating that the request has been accepted for processing, but the processing has not been completed."
+            Response 202 Imsx_StatusInfo 1                          "As defined in [[rfc9110]], indicating that the request has been accepted for processing, but the processing has not been completed."
             Responses PutErrorResponses
             Scopes [putProfileAcg, putProfileCcg]
 

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -19,7 +19,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Responses GetErrorResponses
             Scopes [getCredentialsAcg, getCredentialsCcg]
 
-        Operation upsertCredential POST /credentials                "Create or replace an AchievementCredential on the [=resource server=], appending it to the list of credentials for the subject, or replace an existing entry in that list. The [=resource server=] MUST use the [=credential equality & comparison=] algorithm to compare and determine initial equality. Response code makes clear which operation has been made."
+        Operation upsertCredential POST /credentials                "Create or replace an AchievementCredential on the [=resource server=], appending it to the list of credentials for the subject, or replace an existing entry in that list. The [=resource server=] MUST use the [=credential equality and comparison=] algorithm to compare and determine initial equality. Response code makes clear which operation has been made."
             Body AchievementCredential 1 application/json           "If the AchievementCredential is not signed with the VC-JWT Proof Format, the request body MUST be a AchievementCredential and the `Content-Type` MUST be `application/json`."
             Body CompactJws 1 text/plain                            "If the AchievementCredential is signed with the VC-JWT Proof Format, the request body MUST be a CompactJws string and the `Content-Type` MUST be `text/plain`."
             Response 200                                            "The AchievementCredential was successfully replaced on the [=resource server=]. The response body MUST be the AchievementCredential in the request."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -19,7 +19,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Responses GetErrorResponses
             Scopes [getCredentialsAcg, getCredentialsCcg]
 
-        Operation upsertCredential POST /credentials                "Create or replace an AchievementCredential on the [=resource server=], appending it to the list of credentials for the subject, or replace an existing entry in that list. The [=resource server=] MUST use the [=credential equality and comparison=] algorithm to compare and determine initial equality. Response code makes clear which operation has been made."
+        Operation upsertCredential POST /credentials                "Create or replace an AchievementCredential on the [=resource server=], appending it to the list of credentials for the subject, or replace an existing entry in that list. The [=resource server=] SHOULD use the [=credential equality and comparison=] algorithm to compare and determine initial equality. Response code makes clear which operation has been made."
             Body AchievementCredential 1 application/json           "If the AchievementCredential is not signed with the VC-JWT Proof Format, the request body MUST be a AchievementCredential and the `Content-Type` MUST be `application/json`."
             Body CompactJws 1 text/plain                            "If the AchievementCredential is signed with the VC-JWT Proof Format, the request body MUST be a CompactJws string and the `Content-Type` MUST be `text/plain`."
             Response 200                                            "The AchievementCredential was successfully replaced on the [=resource server=]. The response body MUST be the AchievementCredential in the request."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -42,6 +42,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Body Profile 1 application/json                         "The request MUST include the entire Profile object. The [=resource server=] MAY respond with 400 BAD_REQUEST to reject data that is known immediately to not be acceptable by the platform, e.g. to reject a "telephone" property if the [=resource server=] cannot validate telephone numbers."
             Response 200
                 Body Profile 1 application/json                     "The matching profile. Successful request responses will be the same as GET Profile and may not include the patched values (as the [=resource server=] may be waiting for asynchronous processes to complete before accepting the value). The values may never become part of the published profile."
+            Response 202                                            "As defined in [[rfc9110]], indicating that the request has been accepted for processing, but the processing has not been completed."
             Responses PutErrorResponses
             Scopes [putProfileAcg, putProfileCcg]
 

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -38,12 +38,12 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Response 404 Imsx_StatusInfo 1                          "As defined in [[rfc9110]], indicating that the origin server did not find a current representation for the target resource or is not willing to disclose that one exists."
             Scopes [getProfileCcg, getProfileAcg]
 
-        Operation postProfile POST /profile                         "Update the profile for the authenticate entity."
+        Operation putProfile POST /profile                         "Update the profile for the authenticate entity."
             Body Profile 1 application/json                         "The request SHOULD only include profile identifier properties to be added to the profile, not any existing data. The [=resource server=] MAY respond with 400 BAD_REQUEST to reject data that is known immediately to not be acceptable by the platform, e.g. to reject a "telephone" property if the [=resource server=] cannot validate telephone numbers."
             Response 200
                 Body Profile 1 application/json                     "The matching profile. Successful request responses will be the same as GET Profile and may not include the patched values (as the [=resource server=] may be waiting for asynchronous processes to complete before accepting the value). The values may never become part of the published profile."
-            Responses PostErrorResponses
-            Scopes [postProfileAcg, postProfileCcg]
+            Responses PutErrorResponses
+            Scopes [putProfileAcg, putProfileCcg]
 
     Interface Discovery
 
@@ -70,6 +70,16 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
         Response 500 Imsx_StatusInfo 1								"As defined in [[rfc9110]]. Implementations SHOULD avoid using this error code - use only if there is catastrophic error and there is not a more appropriate code."
         Response Default Imsx_StatusInfo 1						    "The request was invalid or cannot be served. The exact error SHOULD be explained in the response payload."
 
+    ResponseList PutErrorResponses
+        Response 304 Imsx_StatusInfo 1								"As defined in [[rfc9110]], indicating that there is no need for the server to transfer a representation of the target resource because the request indicates that the client, which made the request conditional, already has a valid representation."
+        Response 400 Imsx_StatusInfo 1								"As defined in [[rfc9110]], indicating that the server cannot or will not process the request due to something that is perceived to be a client error."
+        Response 401 Imsx_StatusInfo 1								"As defined in [[rfc9110]], indicating that the request has not been applied because it lacks valid authentication credentials for the target resource."
+        Response 403 Imsx_StatusInfo 1								"As defined in [[rfc9110]], indicating that the server understood the request but refuses to fulfill it. The exact reason SHOULD be explained in the response payload."
+        Response 404 Imsx_StatusInfo 1                              "As defined in [[rfc9110]], indicating that the origin server did not find a current representation for the target resource or is not willing to disclose that one exists."
+        Response 405 Imsx_StatusInfo 1								"As defined in [[rfc9110]], indicating that the server does not allow the method."
+        Response 500 Imsx_StatusInfo 1								"As defined in [[rfc9110]]. Implementations SHOULD avoid using this error code - use only if there is catastrophic error and there is not a more appropriate code."
+        Response Default Imsx_StatusInfo 1						    "The request was invalid or cannot be served. The exact error SHOULD be explained in the response payload."
+
 
 Package ApiDataModels DataModel
 
@@ -84,11 +94,11 @@ Package ACGSecurity SecurityModel OAUTH2ACG
 	Scope getCredentialsAcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.readonly      "Permission to read ClrCredentials for the authenticated entity."
     Scope postCredentialAcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.create        "Permission to create or update ClrCredentials for the authenticated entity."
 	Scope getProfileAcg     https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.readonly         "Permission to read the profile for the authenticated entity."
-    Scope postProfileAcg    https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.update 			"Permission to update the profile for the authenticated entity."
+    Scope putProfileAcg    https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.update 			"Permission to update the profile for the authenticated entity."
 
 Package CCGSecurity SecurityModel OAUTH2CCG
 	Url TokenURL provider.example.com/token
 	Scope getCredentialsCcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.readonly      "Permission to read ClrCredentials for the authenticated entity."
     Scope postCredentialCcg https://purl.imsglobal.org/spec/ob/v3p0/scope/credential.create        "Permission to create or update ClrCredentials for the authenticated entity."
 	Scope getProfileCcg     https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.readonly         "Permission to read the profile for the authenticated entity."
-    Scope postProfileCcg    https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.update 			"Permission to update the profile for the authenticated entity."
+    Scope putProfileCcg    https://purl.imsglobal.org/spec/ob/v3p0/scope/profile.update 			"Permission to update the profile for the authenticated entity."

--- a/ob_v3p0/ob_v3p0.lines
+++ b/ob_v3p0/ob_v3p0.lines
@@ -19,7 +19,7 @@ Package ApiServiceModel ServiceModel REST /ims/ob/v3p0              "The Open Ba
             Responses GetErrorResponses
             Scopes [getCredentialsAcg, getCredentialsCcg]
 
-        Operation upsertCredential POST /credentials                "Create or replace an AchievementCredential on the [=resource server=]."
+        Operation upsertCredential POST /credentials                "Create or replace an AchievementCredential on the [=resource server=], appending it to the list of credentials for the subject, or replace an existing entry in that list. The [=resource server=] MUST use the [=credential equality & comparison=] algorithm to compare and determine initial equality. Response code makes clear which operation has been made."
             Body AchievementCredential 1 application/json           "If the AchievementCredential is not signed with the VC-JWT Proof Format, the request body MUST be a AchievementCredential and the `Content-Type` MUST be `application/json`."
             Body CompactJws 1 text/plain                            "If the AchievementCredential is signed with the VC-JWT Proof Format, the request body MUST be a CompactJws string and the `Content-Type` MUST be `text/plain`."
             Response 200                                            "The AchievementCredential was successfully replaced on the [=resource server=]. The response body MUST be the AchievementCredential in the request."


### PR DESCRIPTION
Renamed methods `postCredential` and `postPofile` to `upsertCredential` and `putProfile` for clarity reasons.