### PR TITLE
Documentation: Update README with contributing guidelines for issue labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For information about how to propose a new feature or material change to the spe
 * __develop__: unstable development branch. Current work that targets a future release is merged into this branch.
 * __feature/new-feature-name__: unstable feature branch. Work that may be approved for future release will be developed in here and branched from __develop__.
 
+## Contibuting
+
 Please follow these steps to contribute a change to the openbadges-specification repository:
 
 1. Open an issue on the repository if you have not done so already to allow for dialog beyond a pull request.
@@ -19,5 +21,18 @@ Please follow these steps to contribute a change to the openbadges-specification
 1. Open a pull request with the target branch of __develop__ and the source of your branch. Please include the issue number when authoring a pull request.
 1. Make your changes aware to the workgroup by raising them during a workgroup meeting. This will typically involve putting the topic on the agenda by way of the workgroup chair and/or an IMS Global staff member.
 1. Pull request or general merges into the __develop__ branch generally require workgroup approval unless IMS Staff or the workgroup chair indicate otherwise.
+
+### Issue Labels
+
+We use labels to track issues. The following labels are used to track the specification lifecycle:
+
+| Label       | Description |
+| ----------- | ----------- |
+| `2p0` | issue relates to OB version 2.0
+| `2p1` | issue relates to OB version 2.1
+| `3p0` | issue relates to OB version 3.0
+| `clr20` | issue relates to version CLR 2.0
+| `candidate_final` | issues is required for Candidate Final release of a specified version
+| `final` | issue is required for Final release of a specified version
 
 IMS Contributing Members may access [Spec Central](https://github.com/IMSGlobal/spec-central/blob/master/github-getting-started.md) for further details about using GitHub for IMS activities.

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Please follow these steps to contribute a change to the openbadges-specification
 We use labels to track issues. The following labels are used to track the specification lifecycle:
 
 | Label       | Description |
-| ----------- | ----------- |
-| `2p0` | issue relates to OB version 2.0
-| `2p1` | issue relates to OB version 2.1
-| `3p0` | issue relates to OB version 3.0
-| `clr20` | issue relates to version CLR 2.0
-| `candidate_final` | issues is required for Candidate Final release of a specified version
-| `final` | issue is required for Final release of a specified version
+| :---------- | :---------- |
+| `2p0` | Issue relates to OB version 2.0
+| `2p1` | Issue relates to OB version 2.1
+| `3p0` | Issue relates to OB version 3.0
+| `clr20` | Issue relates to version CLR 2.0
+| `candidate_final` | Issues is required for Candidate Final release of a specified version
+| `final` | Issue is required for Final release of a specified version
 
 IMS Contributing Members may access [Spec Central](https://github.com/IMSGlobal/spec-central/blob/master/github-getting-started.md) for further details about using GitHub for IMS activities.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ We use labels to track issues. The following labels are used to track the specif
 | `2p0` | Issue relates to OB version 2.0
 | `2p1` | Issue relates to OB version 2.1
 | `3p0` | Issue relates to OB version 3.0
-| `clr20` | Issue relates to version CLR 2.0
-| `candidate_final` | Issues is required for Candidate Final release of a specified version
-| `final` | Issue is required for Final release of a specified version
+| `clr20` | Issue relates to CLR version 2.0
+| `candidate_final` | Issues is required for Candidate Final release of specification version
+| `final` | Issue is required for Final release of specification version
 
 IMS Contributing Members may access [Spec Central](https://github.com/IMSGlobal/spec-central/blob/master/github-getting-started.md) for further details about using GitHub for IMS activities.


### PR DESCRIPTION
As discussed in 10.20.2022 workgroup meeting:
This PR adds a description to labels (related to the specification lifecycle) to the README.

I also recommend adding a description to the labels themselves within Github.
